### PR TITLE
CleanUp of the multi-template-rendering mess.

### DIFF
--- a/src/main/java/com/structurize/coremod/blocks/MultiBlock.java
+++ b/src/main/java/com/structurize/coremod/blocks/MultiBlock.java
@@ -80,6 +80,7 @@ public class MultiBlock extends AbstractBlockStructurize<MultiBlock>
         return true;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void neighborChanged(final IBlockState state, final World worldIn, final BlockPos pos, final Block blockIn, final BlockPos fromPos)
     {

--- a/src/main/java/com/structurize/coremod/proxy/ClientProxy.java
+++ b/src/main/java/com/structurize/coremod/proxy/ClientProxy.java
@@ -218,12 +218,6 @@ public class ClientProxy extends CommonProxy
           (b) -> b.blockState.getBlock() instanceof BlockSubstitution,
           (b) -> new Template.BlockInfo(b.pos, Blocks.AIR.getDefaultState(), null)
         );
-
-        //We disable rendering of the Banner Block
-        TemplateBlockInfoTransformHandler.getInstance().AddTransformHandler(
-          blockInfo -> blockInfo.blockState.getBlock() instanceof BlockBanner,
-          blockInfo -> new Template.BlockInfo(blockInfo.pos, Blocks.AIR.getDefaultState(), null)
-        );
     }
 
     @Override

--- a/src/main/java/com/structurize/coremod/proxy/ClientProxy.java
+++ b/src/main/java/com/structurize/coremod/proxy/ClientProxy.java
@@ -16,6 +16,7 @@ import com.structurize.coremod.event.ClientEventHandler;
 import com.structurize.coremod.items.ModItems;
 import com.structurize.structures.client.TemplateBlockAccess;
 import com.structurize.structures.client.TemplateBlockInfoTransformHandler;
+import com.structurize.structures.client.TemplateEntityInfoTransformHandler;
 import com.structurize.structures.event.RenderEventHandler;
 import com.structurize.structures.helpers.Settings;
 import net.minecraft.block.Block;
@@ -28,6 +29,7 @@ import net.minecraft.client.renderer.block.statemap.StateMap;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.stats.RecipeBook;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
@@ -224,6 +226,8 @@ public class ClientProxy extends CommonProxy
           (b) -> b.blockState.getBlock() == ModBlocks.blockSolidSubstitution,
           (b) -> new Template.BlockInfo(b.pos, Blocks.AIR.getDefaultState(), null)
         );
+
+
     }
 
     @Override

--- a/src/main/java/com/structurize/coremod/proxy/ClientProxy.java
+++ b/src/main/java/com/structurize/coremod/proxy/ClientProxy.java
@@ -215,7 +215,13 @@ public class ClientProxy extends CommonProxy
 
         //Additionally we register an exclusion handler here;
         TemplateBlockInfoTransformHandler.getInstance().AddTransformHandler(
-          (b) -> b.blockState.getBlock() instanceof BlockSubstitution,
+          (b) -> b.blockState.getBlock() == ModBlocks.blockSubstitution,
+          (b) -> new Template.BlockInfo(b.pos, Blocks.AIR.getDefaultState(), null)
+        );
+
+        //Additionally we register an exclusion handler here;
+        TemplateBlockInfoTransformHandler.getInstance().AddTransformHandler(
+          (b) -> b.blockState.getBlock() == ModBlocks.blockSolidSubstitution,
           (b) -> new Template.BlockInfo(b.pos, Blocks.AIR.getDefaultState(), null)
         );
     }

--- a/src/main/java/com/structurize/coremod/proxy/ClientProxy.java
+++ b/src/main/java/com/structurize/coremod/proxy/ClientProxy.java
@@ -14,10 +14,12 @@ import com.structurize.coremod.management.Manager;
 import com.structurize.coremod.management.Structures;
 import com.structurize.coremod.event.ClientEventHandler;
 import com.structurize.coremod.items.ModItems;
-import com.structurize.structures.client.TemplateBlockAccessTransformHandler;
+import com.structurize.structures.client.TemplateBlockAccess;
+import com.structurize.structures.client.TemplateBlockInfoTransformHandler;
 import com.structurize.structures.event.RenderEventHandler;
 import com.structurize.structures.helpers.Settings;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockBanner;
 import net.minecraft.block.BlockPlanks;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
@@ -212,9 +214,15 @@ public class ClientProxy extends CommonProxy
         createCustomModel(ModBlocks.multiBlock);
 
         //Additionally we register an exclusion handler here;
-        TemplateBlockAccessTransformHandler.getInstance().AddTransformHandler(
+        TemplateBlockInfoTransformHandler.getInstance().AddTransformHandler(
           (b) -> b.blockState.getBlock() instanceof BlockSubstitution,
           (b) -> new Template.BlockInfo(b.pos, Blocks.AIR.getDefaultState(), null)
+        );
+
+        //We disable rendering of the Banner Block
+        TemplateBlockInfoTransformHandler.getInstance().AddTransformHandler(
+          blockInfo -> blockInfo.blockState.getBlock() instanceof BlockBanner,
+          blockInfo -> new Template.BlockInfo(blockInfo.pos, Blocks.AIR.getDefaultState(), null)
         );
     }
 

--- a/src/main/java/com/structurize/structures/client/StructureClientHandler.java
+++ b/src/main/java/com/structurize/structures/client/StructureClientHandler.java
@@ -39,7 +39,7 @@ public final class StructureClientHandler
             renderOffset.y = renderOffsetY;
             renderOffset.z = renderOffsetZ;
 
-            Settings.renderHandler.draw(structure.getTemplate(), structure.getSettings().getRotation(), structure.getSettings().getMirror(), renderOffset, partialTicks, pos);
+            TemplateRenderHandler.getInstance().draw(structure.getTemplate(), structure.getSettings().getRotation(), structure.getSettings().getMirror(), renderOffset, partialTicks, pos);
         }
     }
 }

--- a/src/main/java/com/structurize/structures/client/StructureClientHandler.java
+++ b/src/main/java/com/structurize/structures/client/StructureClientHandler.java
@@ -39,7 +39,7 @@ public final class StructureClientHandler
             renderOffset.y = renderOffsetY;
             renderOffset.z = renderOffsetZ;
 
-            TemplateRenderHandler.getInstance().draw(structure.getTemplate(), structure.getSettings().getRotation(), structure.getSettings().getMirror(), renderOffset, partialTicks, pos);
+            TemplateRenderHandler.getInstance().draw(structure.getTemplate(), structure.getSettings().getRotation(), structure.getSettings().getMirror(), renderOffset);
         }
     }
 }

--- a/src/main/java/com/structurize/structures/client/TemplateBlockAccess.java
+++ b/src/main/java/com/structurize/structures/client/TemplateBlockAccess.java
@@ -3,6 +3,7 @@ package com.structurize.structures.client;
 import com.structurize.structures.lib.TemplateUtils;
 import net.minecraft.block.BlockAir;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.Minecraft;
 import net.minecraft.init.Biomes;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
@@ -33,7 +34,7 @@ public class TemplateBlockAccess extends World implements IBlockAccess
      */
     public TemplateBlockAccess(final Template template)
     {
-        super(null, null, new WorldProviderSurface(), null, true);
+        super(Minecraft.getMinecraft().world.getSaveHandler(), Minecraft.getMinecraft().world.getWorldInfo(), new WorldProviderSurface(), Minecraft.getMinecraft().world.profiler, true);
         this.template = template;
     }
 

--- a/src/main/java/com/structurize/structures/client/TemplateBlockAccess.java
+++ b/src/main/java/com/structurize/structures/client/TemplateBlockAccess.java
@@ -53,7 +53,19 @@ public class TemplateBlockAccess extends World implements IBlockAccess
     @Override
     public int getCombinedLight(@NotNull final BlockPos pos, final int lightValue)
     {
-        return lightValue;
+        return 15 << 20 | 15 << 4;
+    }
+
+    @Override
+    public int getLight(final BlockPos pos)
+    {
+        return 15;
+    }
+
+    @Override
+    public float getLightBrightness(final BlockPos pos)
+    {
+        return 1f;
     }
 
     @NotNull
@@ -72,7 +84,7 @@ public class TemplateBlockAccess extends World implements IBlockAccess
     @Override
     protected boolean isChunkLoaded(final int x, final int z, final boolean allowEmpty)
     {
-        return false;
+        return true;
     }
 
     @NotNull
@@ -85,7 +97,7 @@ public class TemplateBlockAccess extends World implements IBlockAccess
     @Override
     protected IChunkProvider createChunkProvider()
     {
-        return null;
+        return Minecraft.getMinecraft().world.getChunkProvider();
     }
 
     @Override

--- a/src/main/java/com/structurize/structures/client/TemplateBlockAccess.java
+++ b/src/main/java/com/structurize/structures/client/TemplateBlockAccess.java
@@ -37,6 +37,11 @@ public class TemplateBlockAccess extends World implements IBlockAccess
         this.template = template;
     }
 
+    public Template getTemplate()
+    {
+        return template;
+    }
+
     @Nullable
     @Override
     public TileEntity getTileEntity(@NotNull final BlockPos pos)

--- a/src/main/java/com/structurize/structures/client/TemplateBlockInfoTransformHandler.java
+++ b/src/main/java/com/structurize/structures/client/TemplateBlockInfoTransformHandler.java
@@ -8,18 +8,18 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-public class TemplateBlockAccessTransformHandler
+public class TemplateBlockInfoTransformHandler
 {
-    private static TemplateBlockAccessTransformHandler ourInstance = new TemplateBlockAccessTransformHandler();
+    private static TemplateBlockInfoTransformHandler ourInstance = new TemplateBlockInfoTransformHandler();
 
-    public static TemplateBlockAccessTransformHandler getInstance()
+    public static TemplateBlockInfoTransformHandler getInstance()
     {
         return ourInstance;
     }
 
     private Map<Predicate<Template.BlockInfo>, Function<Template.BlockInfo, Template.BlockInfo>> blockInfoTransformHandler = new HashMap<>();
 
-    private TemplateBlockAccessTransformHandler()
+    private TemplateBlockInfoTransformHandler()
     {
     }
 

--- a/src/main/java/com/structurize/structures/client/TemplateBlockInfoTransformHandler.java
+++ b/src/main/java/com/structurize/structures/client/TemplateBlockInfoTransformHandler.java
@@ -8,6 +8,9 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+/**
+ * Registry and handler for modifying template information with regards to blocks.
+ */
 public class TemplateBlockInfoTransformHandler
 {
     private static TemplateBlockInfoTransformHandler ourInstance = new TemplateBlockInfoTransformHandler();
@@ -23,11 +26,23 @@ public class TemplateBlockInfoTransformHandler
     {
     }
 
+    /**
+     * Method to add a transformer.
+     *
+     * @param transformPredicate The predicate to check if this transform function needs to be applied.
+     * @param transformHandler The tranformer.
+     */
     public void AddTransformHandler(@NotNull final Predicate<Template.BlockInfo> transformPredicate, @NotNull final Function<Template.BlockInfo, Template.BlockInfo> transformHandler)
     {
         blockInfoTransformHandler.put(transformPredicate, transformHandler);
     }
 
+    /**
+     * Process a blockinfo. Checks all known transformers and applies the first it finds.
+     *
+     * @param blockInfo The block info to transform
+     * @return The transformed blockinfo.
+     */
     public Template.BlockInfo Transform(@NotNull final Template.BlockInfo blockInfo)
     {
         return getTransformHandler(blockInfo).apply(blockInfo);

--- a/src/main/java/com/structurize/structures/client/TemplateEntityInfoTransformHandler.java
+++ b/src/main/java/com/structurize/structures/client/TemplateEntityInfoTransformHandler.java
@@ -8,6 +8,9 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+/**
+ * Registry and handler for modifying template information with regards to entities.
+ */
 public class TemplateEntityInfoTransformHandler
 {
     private static TemplateEntityInfoTransformHandler ourInstance = new TemplateEntityInfoTransformHandler();
@@ -23,11 +26,23 @@ public class TemplateEntityInfoTransformHandler
     {
     }
 
+    /**
+     * Method to add a transformer.
+     *
+     * @param transformPredicate The predicate to check if this transform function needs to be applied.
+     * @param transformHandler The tranformer.
+     */
     public void AddTransformHandler(@NotNull final Predicate<Template.EntityInfo> transformPredicate, @NotNull final Function<Template.EntityInfo, Template.EntityInfo> transformHandler)
     {
         entityInfoTransformHandler.put(transformPredicate, transformHandler);
     }
 
+    /**
+     * Process a entityinfo. Checks all known transformers and applies the first it finds.
+     *
+     * @param entityInfo The entity info to transform
+     * @return The transformed entityinfo.
+     */
     public Template.EntityInfo Transform(@NotNull final Template.EntityInfo entityInfo)
     {
         return getTransformHandler(entityInfo).apply(entityInfo);

--- a/src/main/java/com/structurize/structures/client/TemplateEntityInfoTransformHandler.java
+++ b/src/main/java/com/structurize/structures/client/TemplateEntityInfoTransformHandler.java
@@ -1,0 +1,40 @@
+package com.structurize.structures.client;
+
+import net.minecraft.world.gen.structure.template.Template;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public class TemplateEntityInfoTransformHandler
+{
+    private static TemplateEntityInfoTransformHandler ourInstance = new TemplateEntityInfoTransformHandler();
+
+    public static TemplateEntityInfoTransformHandler getInstance()
+    {
+        return ourInstance;
+    }
+
+    private Map<Predicate<Template.EntityInfo>, Function<Template.EntityInfo, Template.EntityInfo>> entityInfoTransformHandler = new HashMap<>();
+
+    private TemplateEntityInfoTransformHandler()
+    {
+    }
+
+    public void AddTransformHandler(@NotNull final Predicate<Template.EntityInfo> transformPredicate, @NotNull final Function<Template.EntityInfo, Template.EntityInfo> transformHandler)
+    {
+        entityInfoTransformHandler.put(transformPredicate, transformHandler);
+    }
+
+    public Template.EntityInfo Transform(@NotNull final Template.EntityInfo entityInfo)
+    {
+        return getTransformHandler(entityInfo).apply(entityInfo);
+    }
+
+    private Function<Template.EntityInfo, Template.EntityInfo> getTransformHandler(@NotNull final Template.EntityInfo entityInfo)
+    {
+        return entityInfoTransformHandler.keySet().stream().filter(p -> p.test(entityInfo)).findFirst().map(p -> entityInfoTransformHandler.get(p)).orElse(Function.identity());
+    }
+}

--- a/src/main/java/com/structurize/structures/client/TemplateRenderHandler.java
+++ b/src/main/java/com/structurize/structures/client/TemplateRenderHandler.java
@@ -68,11 +68,11 @@ public final class TemplateRenderHandler
      * @param mirror        its mirror.
      * @param drawingOffset its offset.
      */
-    public void draw(final Template template, final Rotation rotation, final Mirror mirror, final Vector3d drawingOffset, final float partialTicks, final BlockPos pos)
+    public void draw(final Template template, final Rotation rotation, final Mirror mirror, final Vector3d drawingOffset)
     {
         try
         {
-            templateBufferBuilderCache.get(template, () -> TemplateRenderer.buildRendererForTemplate(template)).draw(rotation, mirror, drawingOffset, partialTicks, pos);
+            templateBufferBuilderCache.get(template, () -> TemplateRenderer.buildRendererForTemplate(template)).draw(rotation, mirror, drawingOffset);
         }
         catch (ExecutionException e)
         {
@@ -110,7 +110,7 @@ public final class TemplateRenderHandler
             renderOffset.y = renderOffsetY;
             renderOffset.z = renderOffsetZ;
 
-            draw(template, Rotation.NONE, Mirror.NONE, renderOffset, partialTicks, coord);
+            draw(template, Rotation.NONE, Mirror.NONE, renderOffset);
         }
     }
 }

--- a/src/main/java/com/structurize/structures/client/TemplateRenderHandler.java
+++ b/src/main/java/com/structurize/structures/client/TemplateRenderHandler.java
@@ -1,26 +1,20 @@
 package com.structurize.structures.client;
 
-import com.structurize.structures.lib.TemplateUtils;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalListener;
+import com.structurize.api.util.Log;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.BlockRendererDispatcher;
 import net.minecraft.client.renderer.Vector3d;
 import net.minecraft.client.renderer.entity.RenderManager;
-import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
-import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.tileentity.TileEntity;
-import net.minecraft.tileentity.TileEntityBanner;
 import net.minecraft.util.Mirror;
 import net.minecraft.util.Rotation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.gen.structure.template.Template;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
-import static org.lwjgl.opengl.GL11.GL_QUADS;
+import java.util.concurrent.ExecutionException;
 
 /**
  * The wayPointTemplate render handler on the client side.
@@ -28,9 +22,18 @@ import static org.lwjgl.opengl.GL11.GL_QUADS;
 public final class TemplateRenderHandler
 {
     /**
-     * The dispatcher.
+     * A static instance on the client.
      */
-    private BlockRendererDispatcher rendererDispatcher;
+    private static final TemplateRenderHandler ourInstance = new TemplateRenderHandler();
+
+    /**
+     * The builder cache.
+     */
+    private final Cache<Template, TemplateRenderer> templateBufferBuilderCache =
+      CacheBuilder.newBuilder()
+        .maximumSize(50)
+        .removalListener((RemovalListener<Template, TemplateRenderer>) notification -> notification.getValue().getTessellator().getBuffer().deleteGlBuffers())
+        .build();
 
     /**
      * Cached entity renderer.
@@ -38,19 +41,24 @@ public final class TemplateRenderHandler
     private RenderManager entityRenderer;
 
     /**
-     * Pregenerated Tile entities
+     * Private constructor to hide public one.
      */
-    private List<TileEntity> tileList;
+    private TemplateRenderHandler()
+    {
+        /*
+         * Intentionally left empty.
+         */
+    }
 
     /**
-     * Pregenerated tessellator
+     * Get the static instance.
+     *
+     * @return a static instance of this class.
      */
-    private TemplateTessellator tessellator;
-
-    /**
-     * The offset of the anchor for the current template
-     */
-    private BlockPos anchorBlockOffset;
+    public static TemplateRenderHandler getInstance()
+    {
+        return ourInstance;
+    }
 
     /**
      * Draw a wayPointTemplate with a rotation, mirror and offset.
@@ -62,75 +70,14 @@ public final class TemplateRenderHandler
      */
     public void draw(final Template template, final Rotation rotation, final Mirror mirror, final Vector3d drawingOffset, final float partialTicks, final BlockPos pos)
     {
-        if (rendererDispatcher == null)
+        try
         {
-            rendererDispatcher = Minecraft.getMinecraft().getBlockRendererDispatcher();
+            templateBufferBuilderCache.get(template, () -> TemplateRenderer.buildRendererForTemplate(template)).draw(rotation, mirror, drawingOffset, partialTicks, pos);
         }
-        if (entityRenderer == null)
+        catch (ExecutionException e)
         {
-            entityRenderer = Minecraft.getMinecraft().getRenderManager();
+            Log.getLogger().error(e);
         }
-
-        // Should not happen, but generate again when missing
-        if (tileList == null || tessellator == null)
-        {
-            pregenerateEntries(template);
-        }
-
-        tessellator.draw(rotation, mirror, drawingOffset, anchorBlockOffset);
-        tileList.forEach(tileEntity -> {
-            tileEntity.setPos(pos.subtract(anchorBlockOffset));
-            TileEntityRendererDispatcher.instance.render(tileEntity, partialTicks, 0);
-        });
-    }
-
-    /**
-     * Pregenerates the tileEntity list and the Tessellator for this template.
-     *
-     * @param template The template to use
-     */
-    public void pregenerateEntries(final Template template)
-    {
-        if (template == null)
-        {
-            return;
-        }
-
-        if (rendererDispatcher == null)
-        {
-            rendererDispatcher = Minecraft.getMinecraft().getBlockRendererDispatcher();
-        }
-
-        // Calculate the anchor offset
-        anchorBlockOffset = TemplateUtils.getPrimaryBlockOffset(template);
-
-        // generate tileEntities
-        tileList = template.blocks.stream()
-                     .filter(blockInfo -> blockInfo.tileentityData != null)
-                     .map(this::constructTileEntities)
-                     .filter(Objects::nonNull)
-                     .collect(Collectors.toList());
-
-        // generate tessellator
-        tessellator = new TemplateTessellator();
-        final TemplateBlockAccess blockAccess = new TemplateBlockAccess(template);
-
-        tessellator.getBuilder().begin(GL_QUADS, DefaultVertexFormats.BLOCK);
-
-        template.blocks.stream()
-          .map(b -> TemplateBlockAccessTransformHandler.getInstance().Transform(b))
-          .forEach(b -> rendererDispatcher.renderBlock(b.blockState, b.pos, blockAccess, tessellator.getBuilder()));
-    }
-
-    @Nullable
-    private TileEntity constructTileEntities(final Template.BlockInfo info)
-    {
-        final TileEntity entity = TileEntity.create(null, info.tileentityData);
-        if (!(entity instanceof TileEntityBanner))
-        {
-            return null;
-        }
-        return entity;
     }
 
     /**
@@ -138,7 +85,7 @@ public final class TemplateRenderHandler
      *
      * @param points       the points to render it at.
      * @param partialTicks the partial ticks.
-     * @param template     the template.
+     * @param template the template.
      */
     public void drawTemplateAtListOfPositions(final List<BlockPos> points, final float partialTicks, final Template template)
     {
@@ -146,6 +93,7 @@ public final class TemplateRenderHandler
         {
             return;
         }
+
         final EntityPlayer perspectiveEntity = Minecraft.getMinecraft().player;
         final double interpolatedEntityPosX = perspectiveEntity.lastTickPosX + (perspectiveEntity.posX - perspectiveEntity.lastTickPosX) * partialTicks;
         final double interpolatedEntityPosY = perspectiveEntity.lastTickPosY + (perspectiveEntity.posY - perspectiveEntity.lastTickPosY) * partialTicks;
@@ -163,20 +111,6 @@ public final class TemplateRenderHandler
             renderOffset.z = renderOffsetZ;
 
             draw(template, Rotation.NONE, Mirror.NONE, renderOffset, partialTicks, coord);
-        }
-    }
-
-    /**
-     * Reset pregenerated entries
-     */
-    public void reset()
-    {
-        if (tessellator != null)
-        {
-            tileList = null;
-            tessellator.getBuffer().deleteGlBuffers();
-            tessellator = null;
-            anchorBlockOffset = null;
         }
     }
 }

--- a/src/main/java/com/structurize/structures/client/TemplateRenderer.java
+++ b/src/main/java/com/structurize/structures/client/TemplateRenderer.java
@@ -88,10 +88,8 @@ public class TemplateRenderer
      * @param rotation The rotation.
      * @param mirror The mirroring.
      * @param drawingOffset The drawing offset.
-     * @param partialTicks The partial tick time.
-     * @param pos The position.
      */
-    public void draw(final Rotation rotation, final Mirror mirror, final Vector3d drawingOffset, final float partialTicks, final BlockPos pos)
+    public void draw(final Rotation rotation, final Mirror mirror, final Vector3d drawingOffset)
     {
         //Handle things like mirror, rotation and offset.
         preTemplateDraw(rotation, mirror, drawingOffset, primaryBlockOffset);

--- a/src/main/java/com/structurize/structures/client/TemplateRenderer.java
+++ b/src/main/java/com/structurize/structures/client/TemplateRenderer.java
@@ -1,0 +1,158 @@
+package com.structurize.structures.client;
+
+import com.structurize.coremod.Structurize;
+import com.structurize.structures.lib.RenderUtil;
+import com.structurize.structures.lib.TemplateUtils;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.Vector3d;
+import net.minecraft.client.renderer.texture.ITextureObject;
+import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
+import net.minecraft.entity.Entity;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.Mirror;
+import net.minecraft.util.Rotation;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.gen.structure.template.Template;
+
+import java.util.List;
+
+import static org.lwjgl.opengl.GL11.*;
+
+/**
+ * The renderer for templates.
+ * Holds all information required to render a Template.
+ */
+public class TemplateRenderer
+{
+    private static final float HALF_PERCENT_SHRINK               = 0.995F;
+
+    private final TemplateBlockAccess blockAccess;
+    private final List<TileEntity>    tileEntities;
+    private final List<Entity>        entities;
+    private final TemplateTessellator tessellator;
+    private final BlockPos            primaryBlockOffset;
+
+    /**
+     * Static factory utility method to handle the extraction of the values from the template.
+     *
+     * @param template The template to create an instance for.
+     * @return The renderer.
+     */
+    public static TemplateRenderer buildRendererForTemplate(Template template)
+    {
+        final TemplateBlockAccess blockAccess = new TemplateBlockAccess(template);
+        final List<TileEntity> tileEntities = TemplateUtils.instantiateTileEntities(template, blockAccess);
+        final List<Entity> entities = TemplateUtils.instantiateEntities(template, blockAccess);
+        final TemplateTessellator templateTessellator = new TemplateTessellator();
+        final BlockPos primaryBlockOffset = TemplateUtils.getPrimaryBlockOffset(template);
+
+        return new TemplateRenderer(blockAccess, tileEntities, entities, templateTessellator, primaryBlockOffset);
+    }
+
+    private TemplateRenderer(
+      final TemplateBlockAccess blockAccess,
+      final List<TileEntity> tileEntities,
+      final List<Entity> entities,
+      final TemplateTessellator tessellator,
+      final BlockPos primaryBlockOffset)
+    {
+        this.blockAccess = blockAccess;
+        this.tileEntities = tileEntities;
+        this.entities = entities;
+        this.tessellator = tessellator;
+        this.primaryBlockOffset = primaryBlockOffset;
+
+        this.setup();
+    }
+
+    /**
+     * Sets up the renders VBO
+     */
+    private void setup()
+    {
+        tessellator.startBuilding();
+
+        blockAccess.getTemplate().blocks.stream()
+          .map(b -> TemplateBlockInfoTransformHandler.getInstance().Transform(b))
+          .forEach(b -> Minecraft.getMinecraft().getBlockRendererDispatcher().renderBlock(b.blockState, b.pos, blockAccess, tessellator.getBuilder()));
+
+        tessellator.finishBuilding();
+    }
+
+    /**
+     * Draws an instance of the template at the given position, with the given rotation, and mirroring.
+     *
+     * @param rotation The rotation.
+     * @param mirror The mirroring.
+     * @param drawingOffset The drawing offset.
+     * @param partialTicks The partial tick time.
+     * @param pos The position.
+     */
+    public void draw(final Rotation rotation, final Mirror mirror, final Vector3d drawingOffset, final float partialTicks, final BlockPos pos)
+    {
+        //Handle things like mirror, rotation and offset.
+        preTemplateDraw(rotation, mirror, drawingOffset, primaryBlockOffset);
+
+        //Draw normal blocks.
+        tessellator.draw();
+
+        //Draw tile entities.
+        tileEntities.forEach(tileEntity -> TileEntityRendererDispatcher.instance.render(tileEntity, partialTicks, 0));
+
+        //Draw entities
+        entities.forEach(entity -> Minecraft.getMinecraft().getRenderManager().renderEntityStatic(entity, partialTicks, true));
+
+        postTemplateDraw();
+    }
+
+    private static void preTemplateDraw(final Rotation rotation, final Mirror mirror, final Vector3d drawingOffset, final BlockPos inTemplateOffset)
+    {
+        final ITextureObject textureObject = Minecraft.getMinecraft().getTextureMapBlocks();
+        GlStateManager.bindTexture(textureObject.getGlTextureId());
+
+        GlStateManager.pushMatrix();
+        GlStateManager.translate(drawingOffset.x, drawingOffset.y, drawingOffset.z);
+
+        final BlockPos rotateInTemplateOffset = inTemplateOffset.rotate(rotation);
+        GlStateManager.translate(-rotateInTemplateOffset.getX(), -rotateInTemplateOffset.getY(), -rotateInTemplateOffset.getZ());
+
+        RenderUtil.applyRotationToYAxis(rotation);
+        RenderUtil.applyMirror(mirror, inTemplateOffset);
+
+        GlStateManager.scale(HALF_PERCENT_SHRINK, HALF_PERCENT_SHRINK, HALF_PERCENT_SHRINK);
+        GlStateManager.enableBlend();
+        GlStateManager.blendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        GlStateManager.resetColor();
+        GlStateManager.pushMatrix();
+    }
+
+    private static void postTemplateDraw()
+    {
+        GlStateManager.popMatrix();
+        GlStateManager.resetColor();
+        GlStateManager.disableBlend();
+        GlStateManager.popMatrix();
+    }
+
+    public TemplateBlockAccess getBlockAccess()
+    {
+        return blockAccess;
+    }
+
+    public List<TileEntity> getTileEntities()
+    {
+        return tileEntities;
+    }
+
+    public TemplateTessellator getTessellator()
+    {
+        return tessellator;
+    }
+
+    public BlockPos getPrimaryBlockOffset()
+    {
+        return primaryBlockOffset;
+    }
+
+}

--- a/src/main/java/com/structurize/structures/client/TemplateTessellator.java
+++ b/src/main/java/com/structurize/structures/client/TemplateTessellator.java
@@ -17,19 +17,18 @@ import static org.lwjgl.opengl.GL11.*;
 public class TemplateTessellator
 {
 
-    private static final int VERTEX_COMPONENT_SIZE = 3;
-    private static final  int   COLOR_COMPONENT_SIZE              = 4;
-    private static final  int   TEX_COORD_COMPONENT_SIZE          = 2;
-    private static final  int   LIGHT_TEX_COORD_COMPONENT_SIZE    = TEX_COORD_COMPONENT_SIZE;
-    private static final  int   VERTEX_SIZE                       = 28;
-    private static final  int   VERTEX_COMPONENT_OFFSET           = 0;
-    private static final  int   COLOR_COMPONENT_OFFSET            = 12;
-    private static final  int   TEX_COORD_COMPONENT_OFFSET        = 16;
-    private static final  int   LIGHT_TEXT_COORD_COMPONENT_OFFSET = 24;
-    private static final float HALF_PERCENT_SHRINK               = 0.995F;
-    private static final int DEFAULT_BUFFER_SIZE = 2097152;
+    private static final int   VERTEX_COMPONENT_SIZE             = 3;
+    private static final int   COLOR_COMPONENT_SIZE              = 4;
+    private static final int   TEX_COORD_COMPONENT_SIZE          = 2;
+    private static final int   LIGHT_TEX_COORD_COMPONENT_SIZE    = TEX_COORD_COMPONENT_SIZE;
+    private static final int   VERTEX_SIZE                       = 28;
+    private static final int   VERTEX_COMPONENT_OFFSET           = 0;
+    private static final int   COLOR_COMPONENT_OFFSET            = 12;
+    private static final int   TEX_COORD_COMPONENT_OFFSET        = 16;
+    private static final int   LIGHT_TEXT_COORD_COMPONENT_OFFSET = 24;
+    private static final int   DEFAULT_BUFFER_SIZE               = 2097152;
 
-    private final BufferBuilder builder;
+    private final BufferBuilder        builder;
     private final VertexBuffer         buffer      = new VertexBuffer(DefaultVertexFormats.BLOCK);
     private final VertexBufferUploader vboUploader = new VertexBufferUploader();
     private       boolean              isReadOnly  = false;
@@ -43,20 +42,9 @@ public class TemplateTessellator
     /**
      * Draws the data set up in this tessellator and resets the state to prepare for new drawing.
      */
-    public void draw(final Rotation rotation, final Mirror mirror, final Vector3d drawingOffset, final BlockPos inTemplateOffset)
+    public void draw()
     {
-        if (!isReadOnly)
-        {
-            this.builder.finishDrawing();
-
-            //Tell optifine that we are loading a new instance into the GPU.
-            //This ensures that normals are calculated so that we know in which direction a face is facing. (Aka what is outside and what inside)
-            OptifineCompat.getInstance().beforeBuilderUpload(this);
-            this.vboUploader.draw(this.builder);
-            this.isReadOnly = true;
-        }
-
-        preTemplateBufferBinding(rotation, mirror, drawingOffset, inTemplateOffset);
+        GlStateManager.pushMatrix();
 
         this.buffer.bindBuffer();
 
@@ -70,28 +58,7 @@ public class TemplateTessellator
 
         this.buffer.unbindBuffer();
 
-        postTemplateBufferUnbinding();
-    }
-
-    private static void preTemplateBufferBinding(final Rotation rotation, final Mirror mirror, final Vector3d drawingOffset, final BlockPos inTemplateOffset)
-    {
-        final ITextureObject textureObject = Minecraft.getMinecraft().getTextureMapBlocks();
-        GlStateManager.bindTexture(textureObject.getGlTextureId());
-
-        GlStateManager.pushMatrix();
-        GlStateManager.translate(drawingOffset.x, drawingOffset.y, drawingOffset.z);
-
-        final BlockPos rotateInTemplateOffset = inTemplateOffset.rotate(rotation);
-        GlStateManager.translate(-rotateInTemplateOffset.getX(), -rotateInTemplateOffset.getY(), -rotateInTemplateOffset.getZ());
-
-        RenderUtil.applyRotationToYAxis(rotation);
-        RenderUtil.applyMirror(mirror, inTemplateOffset);
-
-        GlStateManager.scale(HALF_PERCENT_SHRINK, HALF_PERCENT_SHRINK, HALF_PERCENT_SHRINK);
-        GlStateManager.enableBlend();
-        GlStateManager.blendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-        GlStateManager.resetColor();
-        GlStateManager.pushMatrix();
+        GlStateManager.popMatrix();
     }
 
     private static void preTemplateDraw()
@@ -109,7 +76,9 @@ public class TemplateTessellator
         //Optifine uses its one vertexformats.
         //It handles the setting of the pointers itself.
         if (OptifineCompat.getInstance().setupArrayPointers())
+        {
             return;
+        }
 
         GlStateManager.glVertexPointer(VERTEX_COMPONENT_SIZE, GL_FLOAT, VERTEX_SIZE, VERTEX_COMPONENT_OFFSET);
         GlStateManager.glColorPointer(COLOR_COMPONENT_SIZE, GL_UNSIGNED_BYTE, VERTEX_SIZE, COLOR_COMPONENT_OFFSET);
@@ -154,12 +123,33 @@ public class TemplateTessellator
         OptifineCompat.getInstance().postTemplateDraw();
     }
 
-    private void postTemplateBufferUnbinding()
+
+    public void startBuilding()
     {
-        GlStateManager.popMatrix();
-        GlStateManager.resetColor();
-        GlStateManager.disableBlend();
-        GlStateManager.popMatrix();
+        if (isReadOnly)
+        {
+            throw new IllegalStateException("Tessellator already build before");
+        }
+
+        builder.begin(GL_QUADS, DefaultVertexFormats.BLOCK);
+    }
+
+    public void finishBuilding()
+    {
+        if (!isReadOnly)
+        {
+            this.builder.finishDrawing();
+
+            //Tell optifine that we are loading a new instance into the GPU.
+            //This ensures that normals are calculated so that we know in which direction a face is facing. (Aka what is outside and what inside)
+            OptifineCompat.getInstance().beforeBuilderUpload(this);
+            this.vboUploader.draw(this.builder);
+            this.isReadOnly = true;
+        }
+        else
+        {
+            throw new IllegalStateException("Tessellator already build before");
+        }
     }
 
     public BufferBuilder getBuilder()

--- a/src/main/java/com/structurize/structures/client/TemplateTessellator.java
+++ b/src/main/java/com/structurize/structures/client/TemplateTessellator.java
@@ -123,7 +123,10 @@ public class TemplateTessellator
         OptifineCompat.getInstance().postTemplateDraw();
     }
 
-
+    /**
+     * Method to start the building of the template VBO.
+     * Can only be called once.
+     */
     public void startBuilding()
     {
         if (isReadOnly)
@@ -134,6 +137,10 @@ public class TemplateTessellator
         builder.begin(GL_QUADS, DefaultVertexFormats.BLOCK);
     }
 
+    /**
+     * Method to end the building of the template VBO.
+     * Can only be called once.
+     */
     public void finishBuilding()
     {
         if (!isReadOnly)

--- a/src/main/java/com/structurize/structures/helpers/Settings.java
+++ b/src/main/java/com/structurize/structures/helpers/Settings.java
@@ -2,7 +2,6 @@ package com.structurize.structures.helpers;
 
 import com.structurize.api.util.Shape;
 import com.structurize.coremod.client.gui.WindowBuildTool;
-import com.structurize.structures.client.TemplateRenderHandler;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Mirror;
@@ -72,11 +71,6 @@ public final class Settings
      * Possible free to place structure.
      */
     private WindowBuildTool.FreeMode freeMode;
-
-    /**
-     * The renderer to use
-     */
-    public static TemplateRenderHandler renderHandler = new TemplateRenderHandler();
 
     /**
      * Private constructor to hide implicit one.
@@ -274,7 +268,6 @@ public final class Settings
         else
         {
             this.structure = structure;
-            renderHandler.pregenerateEntries(structure.getTemplate());
         }
     }
 
@@ -290,8 +283,6 @@ public final class Settings
         isMirrored = false;
         staticSchematicMode = false;
         staticSchematicName = "";
-
-        renderHandler.reset();
     }
 
     /**

--- a/src/main/java/com/structurize/structures/lib/TemplateUtils.java
+++ b/src/main/java/com/structurize/structures/lib/TemplateUtils.java
@@ -146,7 +146,10 @@ public final class TemplateUtils
             compound.setInteger("y", info.pos.getY());
             compound.setInteger("z", info.pos.getZ());
 
-            return TileEntity.create(blockAccess, compound);
+            final TileEntity entity = TileEntity.create(blockAccess, compound);
+            entity.setWorld(blockAccess);
+
+            return entity;
         }
         catch (Exception ex)
         {
@@ -179,6 +182,9 @@ public final class TemplateUtils
             nbttaglist.appendTag(new NBTTagDouble(vec3d1.z));
             compound.setTag("Pos", nbttaglist);
             compound.setUniqueId("UUID", UUID.randomUUID());
+            compound.setInteger("TileX", (int) vec3d1.x);
+            compound.setInteger("TileY", (int) vec3d1.y);
+            compound.setInteger("TileZ", (int) vec3d1.z);
 
             return EntityList.createEntityFromNBT(compound, blockAccess);
         }

--- a/src/main/java/com/structurize/structures/lib/TemplateUtils.java
+++ b/src/main/java/com/structurize/structures/lib/TemplateUtils.java
@@ -150,7 +150,7 @@ public final class TemplateUtils
         }
         catch (Exception ex)
         {
-            Structurize.getLogger().error("Could not create entity: " + entityId + " with nbt: " + info.tileentityData.toString());
+            Structurize.getLogger().error("Could not create tile entity: " + entityId + " with nbt: " + info.tileentityData.toString(), ex);
             blackListedTileEntityIds.add(entityId);
             return null;
         }
@@ -184,7 +184,7 @@ public final class TemplateUtils
         }
         catch (Exception ex)
         {
-            Structurize.getLogger().error("Could not create entity: " + entityId + " with nbt: " + info.entityData.toString());
+            Structurize.getLogger().error("Could not create entity: " + entityId + " with nbt: " + info.entityData.toString(), ex);
             blackListedEntityIds.add(entityId);
             return null;
         }

--- a/src/main/java/com/structurize/structures/lib/TemplateUtils.java
+++ b/src/main/java/com/structurize/structures/lib/TemplateUtils.java
@@ -3,18 +3,28 @@ package com.structurize.structures.lib;
 import com.google.common.base.Functions;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.Sets;
 import com.structurize.blockout.Log;
+import com.structurize.coremod.Structurize;
 import com.structurize.coremod.blocks.interfaces.IAnchorBlock;
 import com.structurize.structures.client.TemplateBlockAccess;
-import com.structurize.structures.client.TemplateBlockAccessTransformHandler;
+import com.structurize.structures.client.TemplateBlockInfoTransformHandler;
+import com.structurize.structures.client.TemplateEntityInfoTransformHandler;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityList;
 import net.minecraft.init.Blocks;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagDouble;
+import net.minecraft.nbt.NBTTagList;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityBanner;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.gen.structure.template.Template;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
@@ -25,6 +35,9 @@ public final class TemplateUtils
 {
     private static final Cache<Template, Map<BlockPos, Template.BlockInfo>> templateBlockInfoCache = CacheBuilder.newBuilder().maximumSize(50).build();
 
+    private static final Set<String> blackListedTileEntityIds = Sets.newHashSet();
+    private static final Set<String> blackListedEntityIds = Sets.newHashSet();
+
     private TemplateUtils()
     {
         throw new IllegalArgumentException("Utils class");
@@ -32,9 +45,10 @@ public final class TemplateUtils
 
     /**
      * Get the tileEntity from a certain position.
+     *
      * @param template the template they are in.
-     * @param pos the position they are at.
-     * @param access the world access to assign them to.
+     * @param pos      the position they are at.
+     * @param access   the world access to assign them to.
      * @return the tileEntity or null.
      */
     public static TileEntity getTileEntityFromPos(final Template template, final BlockPos pos, final TemplateBlockAccess access)
@@ -51,10 +65,12 @@ public final class TemplateUtils
     {
         try
         {
-            return TemplateBlockAccessTransformHandler.getInstance().Transform(Optional.ofNullable(templateBlockInfoCache
-                                         .get(template, () -> template.blocks.stream().collect(Collectors.toMap(bi -> bi.pos, Functions.identity())))
-                                         .get(pos))
-                     .orElse(new Template.BlockInfo(pos, Blocks.AIR.getDefaultState(), null)));
+            return TemplateBlockInfoTransformHandler.getInstance().Transform(Optional.ofNullable(templateBlockInfoCache
+                                                                                                   .get(template,
+                                                                                                     () -> template.blocks.stream()
+                                                                                                             .collect(Collectors.toMap(bi -> bi.pos, Functions.identity())))
+                                                                                                   .get(pos))
+                                                                               .orElse(new Template.BlockInfo(pos, Blocks.AIR.getDefaultState(), null)));
         }
         catch (ExecutionException e)
         {
@@ -69,8 +85,108 @@ public final class TemplateUtils
         return template.blocks.stream()
                  .filter(blockInfo -> blockInfo.blockState.getBlock() instanceof IAnchorBlock)
                  .findFirst()
-                 .map(blockInfo -> TemplateBlockAccessTransformHandler.getInstance().Transform(blockInfo))
+                 .map(blockInfo -> TemplateBlockInfoTransformHandler.getInstance().Transform(blockInfo))
                  .map(blockInfo -> blockInfo.pos)
                  .orElse(new BlockPos(template.getSize().getX() / 2, 0, template.getSize().getZ() / 2));
+    }
+
+    /**
+     * Creates a list of tileentities located in the template, placed inside that templates block access world.
+     *
+     * @param template    The template whos tileentities need to be instantiated.
+     * @param blockAccess The templates world.
+     * @return A list of tileentities in the template
+     */
+    @NotNull
+    public static List<TileEntity> instantiateTileEntities(@NotNull final Template template, @NotNull final TemplateBlockAccess blockAccess)
+    {
+        return template.blocks.stream()
+                 .map(blockInfo -> TemplateBlockInfoTransformHandler.getInstance().Transform(blockInfo))
+                 .filter(blockInfo -> blockInfo.tileentityData != null)
+                 .map(blockInfo -> constructTileEntity(blockInfo, blockAccess))
+                 .filter(Objects::nonNull)
+                 .collect(
+                   Collectors.toList());
+    }
+
+    /**
+     * Creates a list of entities located in the template, placed inside that templates block access world.
+     *
+     * @param template    The template whos entities need to be instantiated.
+     * @param blockAccess The templates world.
+     * @return A list of entities in the template
+     */
+    @NotNull
+    public static List<Entity> instantiateEntities(@NotNull final Template template, @NotNull final TemplateBlockAccess blockAccess)
+    {
+        return template.entities.stream()
+                 .map(entityInfo -> TemplateEntityInfoTransformHandler.getInstance().Transform(entityInfo))
+                 .map(entityInfo -> constructEntity(entityInfo, blockAccess))
+                 .filter(Objects::nonNull)
+                 .collect(Collectors.toList());
+    }
+
+    @Nullable
+    private static TileEntity constructTileEntity(@NotNull final Template.BlockInfo info, @NotNull final TemplateBlockAccess blockAccess)
+    {
+        if (info.tileentityData == null)
+            return null;
+
+        final String entityId = info.tileentityData.getString("id");
+
+        //We know that this is going to fail.
+        //Fail fast.
+        if (blackListedTileEntityIds.contains(entityId))
+            return null;
+
+        try
+        {
+            final NBTTagCompound compound = info.tileentityData.copy();
+            compound.setInteger("x", info.pos.getX());
+            compound.setInteger("y", info.pos.getY());
+            compound.setInteger("z", info.pos.getZ());
+
+            return TileEntity.create(blockAccess, compound);
+        }
+        catch (Exception ex)
+        {
+            Structurize.getLogger().error("Could not create entity: " + entityId);
+            blackListedEntityIds.add(entityId);
+            return null;
+        }
+    }
+
+    @Nullable
+    private static Entity constructEntity(@NotNull final Template.EntityInfo info, @NotNull final TemplateBlockAccess blockAccess)
+    {
+        if (info.entityData == null)
+            return null;
+
+        final String entityId = info.entityData.getString("id");
+
+        //We know that this is going to fail.
+        //Fail fast.
+        if (blackListedEntityIds.contains(entityId))
+            return null;
+
+        try
+        {
+            final NBTTagCompound compound = info.entityData.copy();
+            Vec3d vec3d1 = info.pos;
+            NBTTagList nbttaglist = new NBTTagList();
+            nbttaglist.appendTag(new NBTTagDouble(vec3d1.x));
+            nbttaglist.appendTag(new NBTTagDouble(vec3d1.y));
+            nbttaglist.appendTag(new NBTTagDouble(vec3d1.z));
+            compound.setTag("Pos", nbttaglist);
+            compound.setUniqueId("UUID", UUID.randomUUID());
+
+            return EntityList.createEntityFromNBT(compound, blockAccess);
+        }
+        catch (Exception ex)
+        {
+            Structurize.getLogger().error("Could not create entity: " + entityId);
+            blackListedEntityIds.add(entityId);
+            return null;
+        }
     }
 }

--- a/src/main/java/com/structurize/structures/lib/TemplateUtils.java
+++ b/src/main/java/com/structurize/structures/lib/TemplateUtils.java
@@ -150,8 +150,8 @@ public final class TemplateUtils
         }
         catch (Exception ex)
         {
-            Structurize.getLogger().error("Could not create entity: " + entityId);
-            blackListedEntityIds.add(entityId);
+            Structurize.getLogger().error("Could not create entity: " + entityId + " with nbt: " + info.tileentityData.toString());
+            blackListedTileEntityIds.add(entityId);
             return null;
         }
     }
@@ -184,7 +184,7 @@ public final class TemplateUtils
         }
         catch (Exception ex)
         {
-            Structurize.getLogger().error("Could not create entity: " + entityId);
+            Structurize.getLogger().error("Could not create entity: " + entityId + " with nbt: " + info.entityData.toString());
             blackListedEntityIds.add(entityId);
             return null;
         }


### PR DESCRIPTION
This cleans up the stuff @Raycoms and @someaddons patched in to make multi template rendering work.

This was the design all along, from when i first started working on this.
Adds compatibility for a lot of things as well: Entities, proper world handling etc.

Also rotates and mirror tile entities and entities now properly, which was never working in any version before.

Please review.

![2019-01-11_19 34 54](https://user-images.githubusercontent.com/5585406/51053122-0fe0fb80-15d9-11e9-8bbf-1c1b45fb54c6.png)
