### PR TITLE
Fix buildtool view bounds not fitting the controls it contains

### DIFF
--- a/src/main/resources/assets/structurize/gui/windowbuildtool.xml
+++ b/src/main/resources/assets/structurize/gui/windowbuildtool.xml
@@ -32,7 +32,7 @@
     <button id="rename" size="114 15" pos="293 20" label="Rename" visible="false"/>
     <button id="delete" size="114 15" pos="293 40" label="Delete" visible="false"/>
 
-    <view size="120 112" pos="160 80">
+    <view size="96 128" pos="160 80">
         <buttonimage id="rotateLeft" source="structurize:textures/gui/buildtool/rotateleft.png" size="32" pos="0 0"/>
         <buttonimage id="up" source="structurize:textures/gui/buildtool/up.png" size="32" pos="32 0"/>
         <buttonimage id="rotateRight" source="structurize:textures/gui/buildtool/rotateright.png" size="32" pos="64 0"/>


### PR DESCRIPTION
# Changes proposed in this pull request:
- Change the view bounds of the build tool from this:
![wrong bounds](https://user-images.githubusercontent.com/20557666/56471530-f95a0400-6453-11e9-81cb-5e3622f8db64.png)
to this:
![right bounds](https://user-images.githubusercontent.com/20557666/56471534-037c0280-6454-11e9-9f09-4bd3b12496cc.png)

This fixes that you can click on the bottom half of the confirm and cancel buttons because they are within the bounds of the view now :)

