### PR TITLE
Schematic scan entities optional

### DIFF
--- a/src/main/java/com/ldtteam/structures/blueprints/v1/BlueprintUtil.java
+++ b/src/main/java/com/ldtteam/structures/blueprints/v1/BlueprintUtil.java
@@ -1,16 +1,10 @@
 package com.ldtteam.structures.blueprints.v1;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.*;
-
-import net.minecraft.entity.EntityHanging;
-import net.minecraft.nbt.*;
-import org.apache.logging.log4j.LogManager;
-
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityHanging;
 import net.minecraft.init.Blocks;
+import net.minecraft.nbt.*;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.datafix.DataFixer;
 import net.minecraft.util.datafix.FixTypes;
@@ -20,6 +14,14 @@ import net.minecraft.util.math.BlockPos.MutableBlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.common.Loader;
+import org.apache.logging.log4j.LogManager;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * @see <a href="http://dark-roleplay.net/other/blueprint_format.php">Blueprint V1 Specification</a>
@@ -38,9 +40,9 @@ public class BlueprintUtil
      * @param sizeZ The Size on the Z-Axis
      * @return the generated Blueprint
      */
-    public static Blueprint createBlueprint(World world, BlockPos pos, short sizeX, short sizeY, short sizeZ)
+    public static Blueprint createBlueprint(World world, BlockPos pos, final boolean saveEntities, short sizeX, short sizeY, short sizeZ)
     {
-        return createBlueprint(world, pos, sizeX, sizeY, sizeZ, null);
+        return createBlueprint(world, pos, saveEntities, sizeX, sizeY, sizeZ, null);
     }
 
     /**
@@ -55,7 +57,7 @@ public class BlueprintUtil
      * @param architects an Array of Architects for the structure
      * @return the generated Blueprint
      */
-    public static Blueprint createBlueprint(World world, BlockPos pos, short sizeX, short sizeY, short sizeZ, String name, String... architects)
+    public static Blueprint createBlueprint(World world, BlockPos pos, final boolean saveEntities, short sizeX, short sizeY, short sizeZ, String name, String... architects)
     {
         final List<IBlockState> pallete = new ArrayList<>();
         //Allways add AIR to Pallete
@@ -106,8 +108,12 @@ public class BlueprintUtil
 
         final List<NBTTagCompound> entitiesTag = new ArrayList<>();
 
-        final List<Entity> entities =
-          world.getEntitiesWithinAABBExcludingEntity(null, new AxisAlignedBB(pos.getX(), pos.getY(), pos.getZ(), pos.getX() + sizeX, pos.getY() + sizeY, pos.getZ() + sizeZ));
+        List<Entity> entities = new ArrayList<>();
+        if (saveEntities)
+        {
+            entities =
+              world.getEntitiesWithinAABBExcludingEntity(null, new AxisAlignedBB(pos.getX(), pos.getY(), pos.getZ(), pos.getX() + sizeX, pos.getY() + sizeY, pos.getZ() + sizeZ));
+        }
 
         for (final Entity entity : entities)
         {

--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowScan.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowScan.java
@@ -1,10 +1,5 @@
 package com.ldtteam.structurize.client.gui;
 
-import com.ldtteam.structurize.network.messages.*;
-import com.ldtteam.structurize.util.BlockUtils;
-import com.ldtteam.structurize.api.util.ItemStackUtils;
-import com.ldtteam.structurize.api.util.ItemStorage;
-import com.ldtteam.structurize.api.util.constant.Constants;
 import com.ldtteam.blockout.Color;
 import com.ldtteam.blockout.Pane;
 import com.ldtteam.blockout.controls.Button;
@@ -12,8 +7,13 @@ import com.ldtteam.blockout.controls.ItemIcon;
 import com.ldtteam.blockout.controls.Label;
 import com.ldtteam.blockout.controls.TextField;
 import com.ldtteam.blockout.views.ScrollingList;
-import com.ldtteam.structurize.Structurize;
 import com.ldtteam.structures.helpers.Settings;
+import com.ldtteam.structurize.Structurize;
+import com.ldtteam.structurize.api.util.ItemStackUtils;
+import com.ldtteam.structurize.api.util.ItemStorage;
+import com.ldtteam.structurize.api.util.constant.Constants;
+import com.ldtteam.structurize.network.messages.*;
+import com.ldtteam.structurize.util.BlockUtils;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
@@ -30,6 +30,7 @@ import net.minecraft.util.text.TextComponentString;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
 import java.util.*;
 
 import static com.ldtteam.structurize.api.util.constant.WindowConstants.*;
@@ -256,7 +257,7 @@ public class WindowScan extends AbstractWindowSkeleton
         final int y2 = Integer.parseInt(pos2y.getText());
         final int z2 = Integer.parseInt(pos2z.getText());
 
-        Structurize.getNetwork().sendToServer(new ScanOnServerMessage(new BlockPos(x1, y1, z1), new BlockPos(x2, y2, z2), name));
+        Structurize.getNetwork().sendToServer(new ScanOnServerMessage(new BlockPos(x1, y1, z1), new BlockPos(x2, y2, z2), name, true));
         Settings.instance.setBox(null);
         close();
     }

--- a/src/main/java/com/ldtteam/structurize/network/messages/ScanOnServerMessage.java
+++ b/src/main/java/com/ldtteam/structurize/network/messages/ScanOnServerMessage.java
@@ -30,6 +30,11 @@ public class ScanOnServerMessage extends AbstractMessage<ScanOnServerMessage, IM
     private String name;
 
     /**
+     * Whether to scan entities
+     */
+    private boolean saveEntities = true;
+
+    /**
      * Empty public constructor.
      */
     public ScanOnServerMessage()
@@ -37,13 +42,13 @@ public class ScanOnServerMessage extends AbstractMessage<ScanOnServerMessage, IM
         super();
     }
 
-
-    public ScanOnServerMessage(@NotNull final BlockPos from, @NotNull final BlockPos to, @NotNull final String name)
+    public ScanOnServerMessage(@NotNull final BlockPos from, @NotNull final BlockPos to, @NotNull final String name, final boolean saveEntities)
     {
         super();
         this.from = from;
         this.to = to;
         this.name = name;
+        this.saveEntities = saveEntities;
     }
 
     @Override
@@ -52,6 +57,7 @@ public class ScanOnServerMessage extends AbstractMessage<ScanOnServerMessage, IM
         name = ByteBufUtils.readUTF8String(buf);
         from = BlockPosUtil.readFromByteBuf(buf);
         to = BlockPosUtil.readFromByteBuf(buf);
+        saveEntities = buf.readBoolean();
     }
 
     @Override
@@ -60,11 +66,12 @@ public class ScanOnServerMessage extends AbstractMessage<ScanOnServerMessage, IM
         ByteBufUtils.writeUTF8String(buf, name);
         BlockPosUtil.writeToByteBuf(buf, from);
         BlockPosUtil.writeToByteBuf(buf, to);
+        buf.writeBoolean(saveEntities);
     }
 
     @Override
     public void messageOnServerThread(final ScanOnServerMessage message, final EntityPlayerMP player)
     {
-        ItemScanTool.saveStructure(player.getEntityWorld(), message.from, message.to, player, message.name);
+        ItemScanTool.saveStructure(player.getEntityWorld(), message.from, message.to, player, message.name, message.saveEntities);
     }
 }


### PR DESCRIPTION
# Changes proposed in this pull request:
This makes saving entities within the scanned area optional for cases where you do not want to save entities at all. E.g. for a backup of the block environment without duplicating entities when placing the scan back in.
Review please
