### PR TITLE
Schematic scan entities optional 1.15

### DIFF
--- a/src/main/java/com/ldtteam/structures/blueprints/v1/BlueprintUtil.java
+++ b/src/main/java/com/ldtteam/structures/blueprints/v1/BlueprintUtil.java
@@ -42,9 +42,9 @@ public class BlueprintUtil
      * @param sizeZ The Size on the Z-Axis
      * @return the generated Blueprint
      */
-    public static Blueprint createBlueprint(World world, BlockPos pos, short sizeX, short sizeY, short sizeZ)
+    public static Blueprint createBlueprint(World world, BlockPos pos, final boolean saveEntities, short sizeX, short sizeY, short sizeZ)
     {
-        return createBlueprint(world, pos, sizeX, sizeY, sizeZ, null);
+        return createBlueprint(world, pos, saveEntities, sizeX, sizeY, sizeZ, null);
     }
 
     /**
@@ -59,7 +59,7 @@ public class BlueprintUtil
      * @param architects an Array of Architects for the structure
      * @return the generated Blueprint
      */
-    public static Blueprint createBlueprint(World world, BlockPos pos, short sizeX, short sizeY, short sizeZ, String name, String... architects)
+    public static Blueprint createBlueprint(World world, BlockPos pos, final boolean saveEntities, short sizeX, short sizeY, short sizeZ, String name, String... architects)
     {
         final List<BlockState> pallete = new ArrayList<>();
         // Allways add AIR to Pallete
@@ -112,9 +112,12 @@ public class BlueprintUtil
 
         final List<CompoundNBT> entitiesTag = new ArrayList<>();
 
-        final List<Entity> entities = world.getEntitiesWithinAABBExcludingEntity(
-            null,
-            new AxisAlignedBB(pos.getX(), pos.getY(), pos.getZ(), pos.getX() + sizeX, pos.getY() + sizeY, pos.getZ() + sizeZ));
+        List<Entity> entities = new ArrayList<>();
+        if (saveEntities)
+        {
+            entities =
+              world.getEntitiesWithinAABBExcludingEntity(null, new AxisAlignedBB(pos.getX(), pos.getY(), pos.getZ(), pos.getX() + sizeX, pos.getY() + sizeY, pos.getZ() + sizeZ));
+        }
 
         for (final Entity entity : entities)
         {

--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowScan.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowScan.java
@@ -257,7 +257,7 @@ public class WindowScan extends AbstractWindowSkeleton
         final int y2 = Integer.parseInt(pos2y.getText());
         final int z2 = Integer.parseInt(pos2z.getText());
 
-        Network.getNetwork().sendToServer(new ScanOnServerMessage(new BlockPos(x1, y1, z1), new BlockPos(x2, y2, z2), name));
+        Network.getNetwork().sendToServer(new ScanOnServerMessage(new BlockPos(x1, y1, z1), new BlockPos(x2, y2, z2), name, true));
         Settings.instance.setBox(null);
         close();
     }

--- a/src/main/java/com/ldtteam/structurize/items/ItemScanTool.java
+++ b/src/main/java/com/ldtteam/structurize/items/ItemScanTool.java
@@ -3,13 +3,13 @@ package com.ldtteam.structurize.items;
 import com.ldtteam.structures.blueprints.v1.Blueprint;
 import com.ldtteam.structures.blueprints.v1.BlueprintUtil;
 import com.ldtteam.structurize.Network;
-import com.ldtteam.structurize.util.LanguageHandler;
 import com.ldtteam.structurize.api.util.Log;
 import com.ldtteam.structurize.api.util.Utils;
 import com.ldtteam.structurize.client.gui.WindowScan;
 import com.ldtteam.structurize.management.StructureName;
 import com.ldtteam.structurize.management.Structures;
 import com.ldtteam.structurize.network.messages.SaveScanMessage;
+import com.ldtteam.structurize.util.LanguageHandler;
 import com.ldtteam.structurize.util.StructureLoadingUtils;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.ServerPlayerEntity;
@@ -63,7 +63,7 @@ public class ItemScanTool extends AbstractItemWithPosSelector
         {
             if (playerIn.isShiftKeyDown())
             {
-                saveStructure(worldIn, start, end, playerIn, null);
+                saveStructure(worldIn, start, end, playerIn, null, true);
             }
         }
         else
@@ -94,6 +94,27 @@ public class ItemScanTool extends AbstractItemWithPosSelector
      */
     public static void saveStructure(@NotNull final World world, @NotNull final BlockPos from, @NotNull final BlockPos to, @NotNull final PlayerEntity player, final String name)
     {
+        saveStructure(world, from, to, player, name, true);
+    }
+
+    /**
+     * Scan the structure and save it to the disk.
+     *
+     * @param world        Current world.
+     * @param from         First corner.
+     * @param to           Second corner.
+     * @param player       causing this action.
+     * @param name         the name of it.
+     * @param saveEntities whether to scan in entities
+     */
+    public static void saveStructure(
+      @NotNull final World world,
+      @NotNull final BlockPos from,
+      @NotNull final BlockPos to,
+      @NotNull final PlayerEntity player,
+      final String name,
+      final boolean saveEntities)
+    {
         final BlockPos blockpos =
           new BlockPos(Math.min(from.getX(), to.getX()), Math.min(from.getY(), to.getY()), Math.min(from.getZ(), to.getZ()));
         final BlockPos blockpos1 =
@@ -117,19 +138,35 @@ public class ItemScanTool extends AbstractItemWithPosSelector
             fileName = name;
         }
 
-        final Blueprint bp = BlueprintUtil.createBlueprint(world, blockpos, (short) size.getX(), (short) size.getY(), (short) size.getZ(), name);
+        final Blueprint bp = BlueprintUtil.createBlueprint(world, blockpos, saveEntities, (short) size.getX(), (short) size.getY(), (short) size.getZ(), name);
         Network.getNetwork().sendToPlayer(new SaveScanMessage(BlueprintUtil.writeBlueprintToNBT(bp), fileName), (ServerPlayerEntity) player);
     }
 
     /**
      * Save a structure on the server.
+     *
      * @param world the world.
-     * @param from the start position.
-     * @param to the end position.
-     * @param name the name.
+     * @param from  the start position.
+     * @param to    the end position.
+     * @param name  the name.
      * @return true if succesful.
      */
     public static boolean saveStructureOnServer(@NotNull final World world, @NotNull final BlockPos from, @NotNull final BlockPos to, final String name)
+    {
+        return saveStructureOnServer(world, from, to, name, true);
+    }
+
+    /**
+     * Save a structure on the server.
+     *
+     * @param world        the world.
+     * @param from         the start position.
+     * @param to           the end position.
+     * @param name         the name.
+     * @param saveEntities whether to scan in entities
+     * @return true if succesful.
+     */
+    public static boolean saveStructureOnServer(@NotNull final World world, @NotNull final BlockPos from, @NotNull final BlockPos to, final String name, final boolean saveEntities)
     {
         final BlockPos blockpos =
           new BlockPos(Math.min(from.getX(), to.getX()), Math.min(from.getY(), to.getY()), Math.min(from.getZ(), to.getZ()));
@@ -161,7 +198,7 @@ public class ItemScanTool extends AbstractItemWithPosSelector
             return false;
         }
 
-        final Blueprint bp = BlueprintUtil.createBlueprint(world, blockpos, (short) size.getX(), (short) size.getY(), (short) size.getZ(), name);
+        final Blueprint bp = BlueprintUtil.createBlueprint(world, blockpos, saveEntities, (short) size.getX(), (short) size.getY(), (short) size.getZ(), name);
 
         final File file = new File(folder.get(0), structureName.toString() + Structures.SCHEMATIC_EXTENSION_NEW);
         Utils.checkDirectory(file.getParentFile());

--- a/src/main/java/com/ldtteam/structurize/network/messages/ScanOnServerMessage.java
+++ b/src/main/java/com/ldtteam/structurize/network/messages/ScanOnServerMessage.java
@@ -29,6 +29,11 @@ public class ScanOnServerMessage implements IMessage
     private String name;
 
     /**
+     * Whether to scan entities
+     */
+    private boolean saveEntities = true;
+
+    /**
      * Empty public constructor.
      */
     public ScanOnServerMessage()
@@ -36,13 +41,13 @@ public class ScanOnServerMessage implements IMessage
         super();
     }
 
-
-    public ScanOnServerMessage(@NotNull final BlockPos from, @NotNull final BlockPos to, @NotNull final String name)
+    public ScanOnServerMessage(@NotNull final BlockPos from, @NotNull final BlockPos to, @NotNull final String name, final boolean saveEntities)
     {
         super();
         this.from = from;
         this.to = to;
         this.name = name;
+        this.saveEntities = saveEntities;
     }
 
     @Override
@@ -51,6 +56,7 @@ public class ScanOnServerMessage implements IMessage
         name = buf.readString(32767);
         from = buf.readBlockPos();
         to = buf.readBlockPos();
+        saveEntities = buf.readBoolean();
     }
 
     @Override
@@ -59,6 +65,7 @@ public class ScanOnServerMessage implements IMessage
         buf.writeString(name);
         buf.writeBlockPos(from);
         buf.writeBlockPos(to);
+        buf.writeBoolean(saveEntities);
     }
 
     @Nullable
@@ -71,6 +78,6 @@ public class ScanOnServerMessage implements IMessage
     @Override
     public void onExecute(final NetworkEvent.Context ctxIn, final boolean isLogicalServer)
     {
-        ItemScanTool.saveStructure(ctxIn.getSender().getEntityWorld(), from, to, ctxIn.getSender(), name);
+        ItemScanTool.saveStructure(ctxIn.getSender().getEntityWorld(), from, to, ctxIn.getSender(), name, saveEntities);
     }
 }


### PR DESCRIPTION
1.15 version of https://github.com/ldtteam/Structurize/pull/90

# Changes proposed in this pull request:
This makes saving entities within the scanned area optional for cases where you do not want to save entities at all. E.g. for a backup of the block environment without duplicating entities when placing the scan back in.
Review please
