### PR TITLE
Add render source

### DIFF
--- a/src/main/java/com/ldtteam/structures/blueprints/v1/Blueprint.java
+++ b/src/main/java/com/ldtteam/structures/blueprints/v1/Blueprint.java
@@ -107,6 +107,11 @@ public class Blueprint
     private BlockPos cachePrimaryOffset = null;
 
     /**
+     * Source of rendering.
+     */
+    private BlockPos renderSource = new BlockPos(0, 0, 0);
+
+    /**
      * Constructor of a new Blueprint.
      *
      * @param sizeX        the x size.
@@ -817,6 +822,7 @@ public class Blueprint
         result = prime * result + ((name == null) ? 0 : name.hashCode());
         result = prime * result + palleteSize;
         result = prime * result + getVolume();
+        result = prime * result + renderSource.hashCode();
         return result;
     }
 
@@ -833,6 +839,17 @@ public class Blueprint
         }
         final Blueprint other = (Blueprint) obj;
         return name.equals(other.name) && palleteSize == other.palleteSize && getVolume() == other.getVolume();
+    }
+
+    /**
+     * Set the render source of the blueprint.
+     * This will be included in the hash to differentiate.
+     * This is supposed to be used for static blueprints that are not moved around only.
+     * @param pos the source position.
+     */
+    public void setRenderSource(final BlockPos pos)
+    {
+        this.renderSource = pos;
     }
 
     /**


### PR DESCRIPTION
Closes #
Closes #
Closes #

I talked a bunch with Orion and Someaddons about this. I think this is the only true solution to this problem.
On the Minecolonies side, for static schematics (that do not change their position), we'll set the source position in the blueprint to be included in the hash. This will solve the problem completely and will avoid any interference


# Changes proposed in this pull request:
- Include Render Source in Blueprint hash
-
-

Review please
