### PR TITLE
Don't overwrite existing schematic names

### DIFF
--- a/src/main/java/com/ldtteam/structurize/items/ItemScanTool.java
+++ b/src/main/java/com/ldtteam/structurize/items/ItemScanTool.java
@@ -181,7 +181,8 @@ public class ItemScanTool extends AbstractItemWithPosSelector
             final TileEntity te = world.getTileEntity(anchorPos.get());
             if (te instanceof IBlueprintDataProvider)
             {
-                if (((IBlueprintDataProvider) te).getSchematicName().length() == 0) {
+                if (((IBlueprintDataProvider) te).getSchematicName().length() == 0)
+                {
                     ((IBlueprintDataProvider) te).setSchematicName(fileName);
                 }
                 ((IBlueprintDataProvider) te).setCorners(from.subtract(anchorPos.get()), to.subtract(anchorPos.get()));

--- a/src/main/java/com/ldtteam/structurize/items/ItemScanTool.java
+++ b/src/main/java/com/ldtteam/structurize/items/ItemScanTool.java
@@ -181,7 +181,9 @@ public class ItemScanTool extends AbstractItemWithPosSelector
             final TileEntity te = world.getTileEntity(anchorPos.get());
             if (te instanceof IBlueprintDataProvider)
             {
-                ((IBlueprintDataProvider) te).setSchematicName(fileName);
+                if (((IBlueprintDataProvider) te).getSchematicName().length() == 0) {
+                    ((IBlueprintDataProvider) te).setSchematicName(fileName);
+                }
                 ((IBlueprintDataProvider) te).setCorners(from.subtract(anchorPos.get()), to.subtract(anchorPos.get()));
             }
         }


### PR DESCRIPTION
Currently, the process of running a scan over an area that contains a
DecorationController from minecolonies will overwrite the schematicName
field in the DecorationController with the filename provided in the scan
tool.  This change modifies the process so that DecorationControllers
with existing schematicNames preserve their values, but empty
DecorationControllers will inherit the filename.

Closes #335

# Changes proposed in this pull request:
- Change the scan tool to preserve existing schematic names in decoration controllers

This is one possible method for fixing this problem, and is sort of the more braindead version of doing so.  It doesn't handle the corner case of a user who doesn't manually edit their DecorationController, and scans the same schematic multiple times with different filenames.  This would result in the DecorationController maintaining the very first filename as a schematicName.  In my opinion, this is a reasonable compromise for a first pass at solving this problem.  Feel free to disagree.

Review please
