### PR TITLE
Expand View sizes when zero

### DIFF
--- a/src/main/java/com/ldtteam/blockout/Pane.java
+++ b/src/main/java/com/ldtteam/blockout/Pane.java
@@ -525,6 +525,9 @@ public class Pane extends AbstractGui
         if (parent != null)
         {
             parent.addChild(this);
+
+            // Allow views to expand zero-widths
+            setSize(width, height);
         }
     }
 
@@ -785,9 +788,6 @@ public class Pane extends AbstractGui
 
     /**
      * Handle onHover element, element must be visible.
-     *
-     * @param mx mouse x
-     * @param my mouse y
      */
     protected void handleHover()
     {

--- a/src/main/java/com/ldtteam/blockout/views/View.java
+++ b/src/main/java/com/ldtteam/blockout/views/View.java
@@ -35,6 +35,13 @@ public class View extends Pane
     public View(final PaneParams params)
     {
         super(params);
+
+        if (params.getParentView() != null) // might be null if created dynamically
+        {
+            if (width == 0) width = params.getParentView().width - x;
+            if (height == 0) height = params.getParentView().height - y;
+        }
+
         padding = params.getInteger("padding", padding);
     }
 
@@ -166,6 +173,33 @@ public class View extends Pane
         for (final Pane child : children)
         {
             child.setWindow(w);
+        }
+    }
+
+    @Override
+    public void setSize(final int w, final int h)
+    {
+        super.setSize(w, h);
+
+        // Allow elements to have their size expanded when zero
+        View p = parent;
+        if (p == null) return;
+
+        if (width == 0)
+        {
+            while (p.width == 0 && p.parent != null)
+            {
+                p = p.parent;
+            }
+            width = p.width - x;
+        }
+        if (height == 0)
+        {
+            while (p.height == 0 && p.parent != null)
+            {
+                p = p.parent;
+            }
+            height = parent.height - y;
         }
     }
 

--- a/src/main/java/com/ldtteam/blockout/views/View.java
+++ b/src/main/java/com/ldtteam/blockout/views/View.java
@@ -191,7 +191,7 @@ public class View extends Pane
             {
                 p = p.parent;
             }
-            width = p.width - x;
+            width = Math.max(0, p.width - x);
         }
         if (height == 0)
         {
@@ -199,7 +199,7 @@ public class View extends Pane
             {
                 p = p.parent;
             }
-            height = p.height - y;
+            height = Math.max(0, p.height - y);
         }
     }
 

--- a/src/main/java/com/ldtteam/blockout/views/View.java
+++ b/src/main/java/com/ldtteam/blockout/views/View.java
@@ -199,7 +199,7 @@ public class View extends Pane
             {
                 p = p.parent;
             }
-            height = parent.height - y;
+            height = p.height - y;
         }
     }
 


### PR DESCRIPTION
Hopefully this does what Ray is looking for :smiley: 

# Changes proposed in this pull request:
- Allows widths and heights of 0 to instead fill out the rest of the parent container
    - Similar to using 100%, except
        - this way can be done automatically when the size is set, 
        - and only adjusts to the end of the container, as opposed to literally 100% of parent size but from its own position


Review please
