### PR TITLE
Build Tool Tooltips, Tag Tool Fixes

### DIFF
--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowBuildTool.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowBuildTool.java
@@ -1,6 +1,7 @@
 package com.ldtteam.structurize.client.gui;
 
 import com.ldtteam.blockout.Log;
+import com.ldtteam.blockout.PaneBuilders;
 import com.ldtteam.blockout.controls.Button;
 import com.ldtteam.blockout.views.DropDownList;
 import com.ldtteam.structures.blueprints.v1.Blueprint;
@@ -27,6 +28,7 @@ import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.util.Rotation;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraftforge.fml.server.ServerLifecycleHooks;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -250,8 +252,12 @@ public class WindowBuildTool extends AbstractWindowSkeleton
 
             if (Minecraft.getInstance().player.isCreative())
             {
-                findPaneOfTypeByID(BUTTON_PASTE, Button.class).setVisible(true);
-                findPaneOfTypeByID(BUTTON_PASTE_NICE, Button.class).setVisible(true);
+                final Button pasteButton = findPaneOfTypeByID(BUTTON_PASTE, Button.class);
+                pasteButton.setVisible(true);
+                PaneBuilders.tooltipBuilder().hoverPane(pasteButton).append(new TranslationTextComponent("structurize.gui.buildtool.paste")).build();
+                final Button pasteButtonNice = findPaneOfTypeByID(BUTTON_PASTE_NICE, Button.class);
+                pasteButtonNice.setVisible(true);
+                PaneBuilders.tooltipBuilder().hoverPane(pasteButtonNice).append(new TranslationTextComponent("structurize.gui.buildtool.pastenice")).build();
             }
             else
             {

--- a/src/main/java/com/ldtteam/structurize/items/ItemTagTool.java
+++ b/src/main/java/com/ldtteam/structurize/items/ItemTagTool.java
@@ -11,7 +11,9 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.*;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ActionResult;
 import net.minecraft.util.ActionResultType;
+import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraft.world.World;
@@ -102,6 +104,19 @@ public class ItemTagTool extends AbstractItemWithPosSelector
             return stack.getOrCreateTag().getString(TAG_CURRENT_TAG);
         }
         return "";
+    }
+
+    @Override
+    public ActionResult<ItemStack> onItemRightClick(World worldIn, PlayerEntity playerIn, Hand handIn)
+    {
+        return new ActionResult<>(
+          onAirRightClick(
+            null,
+            null,
+            worldIn,
+            playerIn,
+            playerIn.getHeldItem(handIn)),
+          playerIn.getHeldItem(handIn));
     }
 
     @Override

--- a/src/main/resources/assets/structurize/lang/en_us.json
+++ b/src/main/resources/assets/structurize/lang/en_us.json
@@ -54,6 +54,8 @@
     "item.possetter.anchorpos": "Anchor pos set to x=%d y=%d z=%d",
     "item.possetter.firstpos": "First pos set to x=%d y=%d z=%d",
     "item.possetter.secondpos": "Second pos set to x=%d y=%d z=%d",
+    "item.possetter.missingpos1": "Missing first position",
+    "item.possetter.missingpos2": "Missing final position",
     "item.sceptersteel.badanchorpos": "The Scan Tool's anchor position is outside the scanned area! Please move it using shift + right-click!",
     "item.sceptersteel.point": "Point one saved: %d %d %d",
     "item.sceptersteel.point2": "Point two saved: %d %d %d.",
@@ -106,5 +108,7 @@
     "structurize.config.windowcachecap.comment": "Sets the maximum number of parsed GUI window files to be stored for quick loading.",
     "structurize.gui.buildtool.creative_only": "Structurize does not support using the build tool when in survival. Switch to creative or install MineColonies and use the MineColonies Builder.",
     "structurize.gui.buildtool.unexpecteddatafixer": "Invalid datafixer detected! Side-effects possible! Check log for more info!",
-    "structurize.gui.replaceblock.ambiguous_properties": "Transformation from %s to %s is ambiguous because the following properties are not present in the source block: %s"
+    "structurize.gui.replaceblock.ambiguous_properties": "Transformation from %s to %s is ambiguous because the following properties are not present in the source block: %s",
+    "structurize.gui.buildtool.paste": "Instantly places the structure into the world, keeping Substitution Blocks.",
+    "structurize.gui.buildtool.pastenice": "Instantly places the structure into the world, as if constructed by a Builder."
 }

--- a/src/main/resources/assets/structurize/lang/en_us.json
+++ b/src/main/resources/assets/structurize/lang/en_us.json
@@ -55,7 +55,7 @@
     "item.possetter.firstpos": "First pos set to x=%d y=%d z=%d",
     "item.possetter.secondpos": "Second pos set to x=%d y=%d z=%d",
     "item.possetter.missingpos1": "Missing first position",
-    "item.possetter.missingpos2": "Missing final position",
+    "item.possetter.missingpos2": "Missing second position",
     "item.sceptersteel.badanchorpos": "The Scan Tool's anchor position is outside the scanned area! Please move it using shift + right-click!",
     "item.sceptersteel.point": "Point one saved: %d %d %d",
     "item.sceptersteel.point2": "Point two saved: %d %d %d.",
@@ -109,6 +109,6 @@
     "structurize.gui.buildtool.creative_only": "Structurize does not support using the build tool when in survival. Switch to creative or install MineColonies and use the MineColonies Builder.",
     "structurize.gui.buildtool.unexpecteddatafixer": "Invalid datafixer detected! Side-effects possible! Check log for more info!",
     "structurize.gui.replaceblock.ambiguous_properties": "Transformation from %s to %s is ambiguous because the following properties are not present in the source block: %s",
-    "structurize.gui.buildtool.paste": "Instantly places the structure into the world, keeping Substitution Blocks.",
+    "structurize.gui.buildtool.paste": "Instantly places the structure into the world, keeping Placeholder Blocks.",
     "structurize.gui.buildtool.pastenice": "Instantly places the structure into the world, as if constructed by a Builder."
 }


### PR DESCRIPTION
# Changes proposed in this pull request:
- Adds tooltips to the Build Tool's creative mode buttons.
- Makes the Tag Tool skip dependency on first/second positions, which it either couldn't set or didn't need, since the `onItemRightClick` mode is really just there to open the TagWindow. (hat tip to [Merced on the discord](https://discord.com/channels/139070364159311872/724810019928801290/843558666099490837) for spotting this issue.)
- Adds translation text to match the item.possetter.missingpos1 and item.possetter.missingpos2 translation keys.

Review please
