### PR TITLE
Fix items not being put into chests.

### DIFF
--- a/src/api/java/com/ldtteam/structurize/api/util/ItemStackUtils.java
+++ b/src/api/java/com/ldtteam/structurize/api/util/ItemStackUtils.java
@@ -1,12 +1,16 @@
 package com.ldtteam.structurize.api.util;
 
+import net.minecraft.block.BlockState;
+import net.minecraft.block.ContainerBlock;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.ArmorStandEntity;
 import net.minecraft.entity.item.ItemFrameEntity;
+import net.minecraft.inventory.ItemStackHelper;
 import net.minecraft.item.*;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.*;
 import net.minecraft.util.Direction;
+import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.vector.Vector3d;
@@ -46,12 +50,19 @@ public final class ItemStackUtils
      * Get itemStack of tileEntityData. Retrieve the data from the tileEntity.
      *
      * @param compound the tileEntity stored in a compound.
-     * @param world the world.
+     * @param state the block.
      * @return the list of itemstacks.
      */
-    public static List<ItemStack> getItemStacksOfTileEntity(final CompoundNBT compound, final World world, final BlockPos pos)
+    public static List<ItemStack> getItemStacksOfTileEntity(final CompoundNBT compound, final BlockState state)
     {
-        final TileEntity tileEntity = TileEntity.readTileEntity(world.getBlockState(pos), compound);
+        if (state.getBlock() instanceof ContainerBlock && compound.contains("Items"))
+        {
+            final NonNullList<ItemStack> items = NonNullList.create();
+            ItemStackHelper.loadAllItems(compound, items);
+            return items;
+        }
+
+        final TileEntity tileEntity = TileEntity.readTileEntity(state, compound);
         if (tileEntity == null)
         {
             return Collections.emptyList();

--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowScan.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowScan.java
@@ -350,7 +350,7 @@ public class WindowScan extends AbstractWindowSkeleton
                         {
                             try
                             {
-                                final List<ItemStack> itemList = new ArrayList<>(ItemStackUtils.getItemStacksOfTileEntity(tileEntity.write(new CompoundNBT()), world, here));
+                                final List<ItemStack> itemList = new ArrayList<>(ItemStackUtils.getItemStacksOfTileEntity(tileEntity.write(new CompoundNBT()), blockState));
                                 for (final ItemStack stack : itemList)
                                 {
                                     addNeededResource(stack, 1);

--- a/src/main/java/com/ldtteam/structurize/placement/handlers/placement/PlacementHandlers.java
+++ b/src/main/java/com/ldtteam/structurize/placement/handlers/placement/PlacementHandlers.java
@@ -718,17 +718,6 @@ public final class PlacementHandlers
                 return ActionProcessingResult.DENY;
             }
 
-            try
-            {
-                // Try detecting inventory content.
-                ItemStackUtils.getItemStacksOfTileEntity(tileEntityData, world, pos);
-            }
-            catch (final Exception ex)
-            {
-                // If we can't load the inventory content of the TE, return early, don't fill TE data.
-                return ActionProcessingResult.SUCCESS;
-            }
-
             if (tileEntityData != null)
             {
                 handleTileEntityPlacement(tileEntityData, world, pos);


### PR DESCRIPTION
Closes #383

# Changes proposed in this pull request:
- Fixes chests being placed empty.

Review please

Removing that redundant bit of code (the return value is ignored, the only thing it does is to throw an exception and return because it was given the wrong world) fixes everything.  The chest is populated as expected.  Double chests also work as expected and don't duplicate anything, no matter what rotation is used.  The only thing that continues to not work is mirroring a double chest -- but even then it has the right items, it just doesn't connect properly (which is not new).