### PR TITLE
Populates the `required_mods` list properly.

### DIFF
--- a/src/main/java/com/ldtteam/structures/blueprints/v1/BlueprintUtil.java
+++ b/src/main/java/com/ldtteam/structures/blueprints/v1/BlueprintUtil.java
@@ -23,6 +23,8 @@ import java.io.OutputStream;
 import java.util.*;
 import java.util.function.Function;
 
+import static com.ldtteam.structurize.api.util.constant.Constants.MOD_ID;
+
 /**
  * @see <a href="http://dark-roleplay.net/other/blueprint_format.php">Blueprint V1 Specification</a>
  * @since 0.1.0
@@ -70,19 +72,16 @@ public class BlueprintUtil
             short x = (short) (mutablePos.getX() - pos.getX()), y = (short) (mutablePos.getY() - pos.getY()),
                 z = (short) (mutablePos.getZ() - pos.getZ());
 
-            if (!modName.equals("minecraft"))
+            if (!modName.equals("minecraft") && !modName.equals(MOD_ID))
             {
-                if (!requiredMods.contains(modName))
-                {
-                    if (!ModList.get().getModContainerById(modName).isPresent())
-                    {
-                        requiredMods.add(modName);
-                    }
-                }
-                else if (!ModList.get().getModContainerById(modName).isPresent())
+                if (!ModList.get().getModContainerById(modName).isPresent())
                 {
                     structure[y][z][x] = (short) pallete.indexOf(Blocks.AIR.getDefaultState());
                     continue;
+                }
+                if (!requiredMods.contains(modName))
+                {
+                    requiredMods.add(modName);
                 }
             }
 
@@ -232,7 +231,7 @@ public class BlueprintUtil
 
         BlockPosUtil.writeToNBT(structurizeTag, "primary_offset", schem.getPrimaryBlockOffset());
 
-        optionalTag.put(Constants.MOD_ID, structurizeTag);
+        optionalTag.put(MOD_ID, structurizeTag);
         tag.put(NBT_OPTIONAL_DATA_TAG, optionalTag);
 
         return tag;
@@ -276,7 +275,7 @@ public class BlueprintUtil
     {
         final String name = oldBlockState.getString("Name");
         oldBlockState.putString("Name", oldBlockState.getString("Name").toLowerCase(Locale.US));
-        if (name.contains(Constants.MOD_ID))
+        if (name.contains(MOD_ID))
         {
             if (name.contains("blockshingle_"))
             {
@@ -554,9 +553,9 @@ public class BlueprintUtil
             if (tag.keySet().contains(NBT_OPTIONAL_DATA_TAG))
             {
                 final CompoundNBT optionalTag = tag.getCompound(NBT_OPTIONAL_DATA_TAG);
-                if (optionalTag.keySet().contains(Constants.MOD_ID))
+                if (optionalTag.keySet().contains(MOD_ID))
                 {
-                    final CompoundNBT structurizeTag = optionalTag.getCompound(Constants.MOD_ID);
+                    final CompoundNBT structurizeTag = optionalTag.getCompound(MOD_ID);
                     BlockPos offsetPos = BlockPosUtil.readFromNBT(structurizeTag, "primary_offset");
                     schem.setCachePrimaryOffset(offsetPos);
                 }


### PR DESCRIPTION
# Changes proposed in this pull request:
- Correctly populates the `required_mods` list in the blueprint data when scanning.

Review please

----
This fixes a bug I noted in ldtteam/minecolonies#7190.  Nothing appears to actually *use* this list at present (much like the `architects` list) but it seems useful to have it correct such that in a future version of structurize it could either automatically hide or just display an error message if you tried to build a schematic that requires blocks from unloaded mods.  Or as part of a schematic lint checker to verify that stray blocks didn't make it into an official style (or to relax that rule if such styles could be automatically hidden when not usable).