### PR TITLE
fix 394

### DIFF
--- a/src/main/java/com/ldtteam/structurize/util/InventoryUtils.java
+++ b/src/main/java/com/ldtteam/structurize/util/InventoryUtils.java
@@ -95,6 +95,8 @@ public class InventoryUtils
     public static void consumeStack(final ItemStack tempStack, final IItemHandler handler)
     {
         int count = tempStack.getCount();
+        final ItemStack container = tempStack.getContainerItem();
+
         for (int i = 0; i < handler.getSlots(); i++)
         {
             if (handler.getStackInSlot(i).isItemEqual(tempStack))
@@ -102,6 +104,13 @@ public class InventoryUtils
                 final ItemStack result = handler.extractItem(i, count, false);
                 if (result.getCount() == count)
                 {
+                    if (!container.isEmpty())
+                    {
+                        for (int j = 0; j < tempStack.getCount(); j++)
+                        {
+                            transferIntoNextBestSlot(container, handler);
+                        }
+                    }
                     return;
                 }
                 count -= result.getCount();


### PR DESCRIPTION
Closes #394
Closes #
Closes #

# Changes proposed in this pull request:
- Properly gives back bucket.
-
-

Now, while debugging this I noticed that our "        boolean sameBlockInWorld = worldState.getBlock() == localState.getBlock();" causes issues with fluids and needs to be revisted.

Review please
