### PR TITLE
Fix input spinner visibility when not using cube shape

### DIFF
--- a/src/api/java/com/ldtteam/structurize/api/util/constant/WindowConstants.java
+++ b/src/api/java/com/ldtteam/structurize/api/util/constant/WindowConstants.java
@@ -155,13 +155,13 @@ public final class WindowConstants
     public static final String INPUT_SHAPE     = "shape";
 
     /**
-     * The labels of the width, length, etc.
+     * The views of the width, length, etc.
      */
-    public static final String HEIGHT_LABEL    = "heightLabel";
-    public static final String WIDTH_LABEL     = "widthLabel";
-    public static final String LENGTH_LABEL    = "lengthLabel";
-    public static final String FREQUENCY_LABEL = "frequencyLabel";
-    public static final String SHAPE_LABEL     = "shapeLabel";
+    public static final String HEIGHT_VIEW    = "heightInput";
+    public static final String WIDTH_VIEW      = "widthInput";
+    public static final String LENGTH_VIEW     = "lengthInput";
+    public static final String FREQUENCY_VIEW  = "frequencyInput";
+    public static final String SHAPE_VIEW      = "shapeInput";
 
     /**
      * The shapeTool Replace Blocks toggle.

--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowShapeTool.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowShapeTool.java
@@ -1,6 +1,5 @@
 package com.ldtteam.structurize.client.gui;
 
-import com.ldtteam.blockout.Pane;
 import com.ldtteam.blockout.controls.*;
 import com.ldtteam.blockout.views.DropDownList;
 import com.ldtteam.blockout.views.View;
@@ -17,14 +16,16 @@ import com.ldtteam.structurize.network.messages.GenerateAndPasteMessage;
 import com.ldtteam.structurize.network.messages.GenerateAndSaveMessage;
 import com.ldtteam.structurize.network.messages.LSStructureDisplayerMessage;
 import com.ldtteam.structurize.network.messages.UndoMessage;
-import com.ldtteam.structurize.util.*;
+import com.ldtteam.structurize.util.BlockUtils;
+import com.ldtteam.structurize.util.LanguageHandler;
+import com.ldtteam.structurize.util.PlacementSettings;
+import com.ldtteam.structurize.util.StructureUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Mirror;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Rotation;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.text.TranslationTextComponent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -36,7 +37,6 @@ import java.util.stream.Collectors;
 
 import static com.ldtteam.structurize.api.util.constant.Constants.*;
 import static com.ldtteam.structurize.api.util.constant.WindowConstants.*;
-import static com.ldtteam.structurize.client.gui.WindowBuildTool.*;
 
 /**
  * BuildTool window.

--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowShapeTool.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowShapeTool.java
@@ -1,7 +1,9 @@
 package com.ldtteam.structurize.client.gui;
 
+import com.ldtteam.blockout.Pane;
 import com.ldtteam.blockout.controls.*;
 import com.ldtteam.blockout.views.DropDownList;
+import com.ldtteam.blockout.views.View;
 import com.ldtteam.structures.blueprints.v1.Blueprint;
 import com.ldtteam.structures.blueprints.v1.BlueprintUtil;
 import com.ldtteam.structures.helpers.Settings;
@@ -211,6 +213,8 @@ public class WindowShapeTool extends AbstractWindowSkeleton
         registerButton(INPUT_LENGTH + BUTTON_PLUS, () -> adjust(inputLength, Settings.instance.getLength() + 1));
         registerButton(INPUT_HEIGHT + BUTTON_MINUS, () -> adjust(inputHeight, Settings.instance.getHeight() - 1));
         registerButton(INPUT_HEIGHT + BUTTON_PLUS, () -> adjust(inputHeight, Settings.instance.getHeight() + 1));
+        registerButton(INPUT_FREQUENCY + BUTTON_MINUS, () -> adjust(inputFrequency, Settings.instance.getFrequency() - 1));
+        registerButton(INPUT_FREQUENCY + BUTTON_PLUS, () -> adjust(inputFrequency, Settings.instance.getFrequency() + 1));
 
         sections.clear();
         sections.addAll(Arrays.stream(Shape.values()).map(Enum::name).collect(Collectors.toList()));
@@ -262,22 +266,17 @@ public class WindowShapeTool extends AbstractWindowSkeleton
     private void disableInputIfNecessary()
     {
         final Shape shape = Settings.instance.getShape();
-        final Text heightLabel = findPaneOfTypeByID(HEIGHT_LABEL, Text.class);
-        final Text widthLabel = findPaneOfTypeByID(WIDTH_LABEL, Text.class);
-        final Text lengthLabel = findPaneOfTypeByID(LENGTH_LABEL, Text.class);
-        final Text frequencyLabel = findPaneOfTypeByID(FREQUENCY_LABEL, Text.class);
-        final Text shapeLabel = findPaneOfTypeByID(SHAPE_LABEL, Text.class);
+        final View height = findPaneOfTypeByID(HEIGHT_VIEW, View.class);
+        final View width = findPaneOfTypeByID(WIDTH_VIEW, View.class);
+        final View length = findPaneOfTypeByID(LENGTH_VIEW, View.class);
+        final View frequency = findPaneOfTypeByID(FREQUENCY_VIEW, View.class);
+        final View equation = findPaneOfTypeByID(SHAPE_VIEW, View.class);
 
-        inputHeight.show();
-        inputWidth.show();
-        inputLength.show();
-        inputFrequency.show();
-        inputShape.hide();
-        heightLabel.show();
-        widthLabel.show();
-        lengthLabel.show();
-        frequencyLabel.show();
-        shapeLabel.hide();
+        height.show();
+        width.show();
+        length.show();
+        frequency.show();
+        equation.hide();
 
         findPaneByID(BUTTON_HOLLOW).show();
         findPaneByID(BUTTON_PICK_FILL_BLOCK).show();
@@ -286,10 +285,8 @@ public class WindowShapeTool extends AbstractWindowSkeleton
 
         if (shape == Shape.RANDOM)
         {
-            inputShape.show();
-            shapeLabel.show();
-            inputFrequency.hide();
-            frequencyLabel.hide();
+            equation.show();
+            frequency.hide();
             findPaneByID(BUTTON_HOLLOW).hide();
             findPaneByID(BUTTON_PICK_FILL_BLOCK).hide();
             findPaneByID(RESOURCE_ICON_FILL).hide();
@@ -297,24 +294,18 @@ public class WindowShapeTool extends AbstractWindowSkeleton
         else if (shape == Shape.SPHERE || shape == Shape.HALF_SPHERE || shape == Shape.BOWL || shape == Shape.PYRAMID || shape == Shape.UPSIDE_DOWN_PYRAMID
                    || shape == Shape.DIAMOND)
         {
-            inputWidth.hide();
-            inputLength.hide();
-            inputFrequency.hide();
-            widthLabel.hide();
-            lengthLabel.hide();
-            frequencyLabel.hide();
+            width.hide();
+            length.hide();
+            frequency.hide();
         }
         else if (shape == Shape.CYLINDER)
         {
-            inputLength.hide();
-            lengthLabel.hide();
-            inputFrequency.hide();
-            frequencyLabel.hide();
+            length.hide();
+            frequency.hide();
         }
         else if (shape != Shape.WAVE && shape != Shape.WAVE_3D)
         {
-            inputFrequency.hide();
-            frequencyLabel.hide();
+            frequency.hide();
         }
     }
 

--- a/src/main/resources/assets/structurize/gui/windowshapetool.xml
+++ b/src/main/resources/assets/structurize/gui/windowshapetool.xml
@@ -26,29 +26,46 @@
     <buttonimage id="nextShape" size="14 15" pos="275 3" label="&gt;"
             source="structurize:textures/gui/builderhut/builder_button_mini.png" textcolor="black"/>
 
-    <label label="Height" id="heightLabel" size="40 20" pos="300 1"/>
-    <label label="Width" id="widthLabel" size="40 20" pos="300 26"/>
-    <label label="Length" id="lengthLabel" size="40 20" pos="300 51"/>
-    <label label="Frequency" id="frequencyLabel" size="40 20" pos="300 76"/>
-    <label label="Shape" id="shapeLabel" size="40 20" pos="120 30"/>
+    <view id="heightInput" size="105 20" pos="300 1">
+        <label label="Height" size="40 20" pos="0 0"/>
+        <input id="height" size="30 20" pos="60 0" maxlength="3"/>
+        <buttonimage id="heightminus" size="14 15" pos="46 2" label="-"
+                     source="structurize:textures/gui/builderhut/builder_button_mini.png" textcolor="black"/>
+        <buttonimage id="heightplus" size="14 15" pos="91 2" label="+"
+                     source="structurize:textures/gui/builderhut/builder_button_mini.png" textcolor="black"/>
+    </view>
 
-    <input id="height" size="30 20" pos="360 1" maxlength="3"/>
-    <input id="width" size="30 20" pos="360 26" maxlength="3"/>
-    <input id="length" size="30 20" pos="360 51" maxlength="3"/>
-    <input id="frequency" size="30 20" pos="360 76" maxlength="3"/>
-    <input id="shape" size="135 20" pos="165 30" maxlength="200"/>
-    <buttonimage id="heightminus" size="14 15" pos="346 3" label="-"
-                 source="structurize:textures/gui/builderhut/builder_button_mini.png" textcolor="black"/>
-    <buttonimage id="heightplus" size="14 15" pos="391 3" label="+"
-                 source="structurize:textures/gui/builderhut/builder_button_mini.png" textcolor="black"/>
-    <buttonimage id="widthminus" size="14 15" pos="346 28" label="-"
-                 source="structurize:textures/gui/builderhut/builder_button_mini.png" textcolor="black"/>
-    <buttonimage id="widthplus" size="14 15" pos="391 28" label="+"
-                 source="structurize:textures/gui/builderhut/builder_button_mini.png" textcolor="black"/>
-    <buttonimage id="lengthminus" size="14 15" pos="346 54" label="-"
-                 source="structurize:textures/gui/builderhut/builder_button_mini.png" textcolor="black"/>
-    <buttonimage id="lengthplus" size="14 15" pos="391 54" label="+"
-                 source="structurize:textures/gui/builderhut/builder_button_mini.png" textcolor="black"/>
+    <view id="widthInput" size="105 20" pos="300 26">
+        <label label="Width" size="40 20" pos="0 0"/>
+        <input id="width" size="30 20" pos="60 0" maxlength="3"/>
+        <buttonimage id="widthminus" size="14 15" pos="46 2" label="-"
+                     source="structurize:textures/gui/builderhut/builder_button_mini.png" textcolor="black"/>
+        <buttonimage id="widthplus" size="14 15" pos="91 2" label="+"
+                     source="structurize:textures/gui/builderhut/builder_button_mini.png" textcolor="black"/>
+    </view>
+
+    <view id="lengthInput" size="105 20" pos="300 51">
+        <label label="Length" size="40 20" pos="0 0"/>
+        <input id="length" size="30 20" pos="60 0" maxlength="3"/>
+        <buttonimage id="lengthminus" size="14 15" pos="46 2" label="-"
+                     source="structurize:textures/gui/builderhut/builder_button_mini.png" textcolor="black"/>
+        <buttonimage id="lengthplus" size="14 15" pos="91 2" label="+"
+                     source="structurize:textures/gui/builderhut/builder_button_mini.png" textcolor="black"/>
+    </view>
+
+    <view id="frequencyInput" size="105 20" pos="300 76">
+        <label label="Frequency" size="40 20" pos="0 0"/>
+        <input id="frequency" size="30 20" pos="60 0" maxlength="3"/>
+        <buttonimage id="frequencyminus" size="14 15" pos="46 2" label="-"
+                     source="structurize:textures/gui/builderhut/builder_button_mini.png" textcolor="black"/>
+        <buttonimage id="frequencyplus" size="14 15" pos="91 2" label="+"
+                     source="structurize:textures/gui/builderhut/builder_button_mini.png" textcolor="black"/>
+    </view>
+
+    <view id="shapeInput" size="180 20" pos="120 30">
+        <label label="Shape" size="40 20" pos="0 0"/>
+        <input id="shape" size="135 20" pos="45 0" maxlength="200"/>
+    </view>
 
     <view size="96 128" pos="162 80">
         <buttonimage id="rotateLeft" source="structurize:textures/gui/buildtool/rotateleft.png" size="32" pos="0 0"/>


### PR DESCRIPTION
# Changes proposed in this pull request:
- Fixes shape tool input spinner behaviour when committing the heresy of using non-cube shapes.

Review please

Apparently I had a bit of tunnel vision when testing the original implementation... these are better.