### PR TITLE
Ignore non-serializable entities (such as players) during scan

### DIFF
--- a/src/main/java/com/ldtteam/structures/blueprints/v1/BlueprintUtil.java
+++ b/src/main/java/com/ldtteam/structures/blueprints/v1/BlueprintUtil.java
@@ -122,6 +122,7 @@ public class BlueprintUtil
         {
             final Vector3d oldPos = entity.position();
             final CompoundNBT entityTag = entity.serializeNBT();
+            if (!entityTag.contains("id")) continue;
 
             final ListNBT posList = new ListNBT();
             posList.add(DoubleNBT.valueOf(oldPos.x - pos.getX()));


### PR DESCRIPTION
Related to ldtteam/minecolonies#7605

# Changes proposed in this pull request:
- Don't bother saving non-serializable entities to save some disk space (they won't get placed anyway)

Review please
