### PR TITLE
Fix groundlevel again

### DIFF
--- a/src/api/java/com/ldtteam/structurize/api/util/constant/Constants.java
+++ b/src/api/java/com/ldtteam/structurize/api/util/constant/Constants.java
@@ -22,6 +22,9 @@ public final class Constants
     public static final double HALF_BLOCK                       = 0.5D;
     public static final String MINECOLONIES_MOD_ID              = "minecolonies";
     public static final String GROUNDLEVEL_TAG                  = "groundlevel";
+    public static final int    GROUNDSTYLE_RELATIVE             = 1; // relative to anchor
+    public static final int    GROUNDSTYLE_LEGACY_CAMP          = 2; // 1 block at bottom
+    public static final int    GROUNDSTYLE_LEGACY_SHIP          = 3; // 3 blocks at bottom
 
     /**
      * Volume to play at.

--- a/src/main/java/com/ldtteam/structures/lib/BlueprintTagUtils.java
+++ b/src/main/java/com/ldtteam/structures/lib/BlueprintTagUtils.java
@@ -4,10 +4,12 @@ import com.ldtteam.structures.blueprints.v1.Blueprint;
 import com.ldtteam.structurize.blocks.interfaces.IBlueprintDataProvider;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.math.BlockPos;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Map;
 
+import static com.ldtteam.structurize.api.util.constant.Constants.GROUNDLEVEL_TAG;
 import static com.ldtteam.structurize.blocks.interfaces.IBlueprintDataProvider.TAG_BLUEPRINTDATA;
 
 /**
@@ -42,5 +44,60 @@ public class BlueprintTagUtils
         }
 
         return null;
+    }
+
+    /**
+     * Gets the number of layers at the bottom of the blueprint that are considered
+     * 'ground' (or water, for ships).
+     * @param blueprint The blueprint to query
+     * @param defaultGroundLevels The number of levels to assume if there is no tag
+     * @return The number of levels, e.g. 1 means that the bottom layer of the
+     *         blueprint is ground and 3 means the bottom 3 layers are ground.
+     */
+    public static int getNumberOfGroundLevels(@NotNull final Blueprint blueprint,
+                                              final int defaultGroundLevels)
+    {
+        final BlockPos groundLevelPos = getFirstPosForTag(blueprint, GROUNDLEVEL_TAG);
+        if (groundLevelPos != null)
+        {
+            return blueprint.getPrimaryBlockOffset().getY() + groundLevelPos.getY() + 1;
+        }
+
+        return defaultGroundLevels;
+    }
+
+    /**
+     * Gets the relative height difference between the blueprint's anchor position and
+     * the 'ground' (or water, for ships).
+     * @param blueprint The blueprint to query
+     * @param defaultGroundOffset The height difference to assume if there is no tag
+     * @return The height difference, e.g. 1 means that the ground level is 1 block below
+     *         the anchor position.  The value may be negative (if the anchor is underground)
+     *         or indicate a position outside the blueprint.
+     */
+    public static int getGroundAnchorOffset(@NotNull final Blueprint blueprint,
+                                            final int defaultGroundOffset)
+    {
+        final BlockPos groundLevelPos = getFirstPosForTag(blueprint, GROUNDLEVEL_TAG);
+        if (groundLevelPos != null)
+        {
+            return -groundLevelPos.getY();
+        }
+
+        return defaultGroundOffset;
+    }
+
+    /**
+     * For a given blueprint, converts a "number of ground levels" value to a ground-anchor
+     * relative height offset.
+     * @param blueprint The associated blueprint
+     * @param groundLevels The number of levels at the bottom of the blueprint that are 'ground'
+     * @return The number of levels below the anchor at which 'ground" starts.  This might be
+     *         negative if the anchor is underground.
+     */
+    public static int getGroundAnchorOffsetFromGroundLevels(@NotNull final Blueprint blueprint,
+                                                            final int groundLevels)
+    {
+        return blueprint.getPrimaryBlockOffset().getY() - groundLevels + 1;
     }
 }

--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowBuildTool.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowBuildTool.java
@@ -890,7 +890,7 @@ public class WindowBuildTool extends AbstractWindowSkeleton
      */
     private void adjustToGroundOffset()
     {
-        int groundOffset = 0;
+        int groundOffset = 1;
         final Blueprint blueprint = Settings.instance.getActiveStructure();
         if (blueprint != null)
         {
@@ -899,6 +899,7 @@ public class WindowBuildTool extends AbstractWindowSkeleton
             {
                 groundOffset = -groundLevel.getY();
             }
+            --groundOffset;
         }
         Settings.instance.setGroundOffset(groundOffset);
     }

--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowStructureNameEntry.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowStructureNameEntry.java
@@ -11,6 +11,8 @@ import com.ldtteam.structurize.management.StructureName;
 import com.ldtteam.structurize.management.Structures;
 import org.jetbrains.annotations.NotNull;
 
+import static com.ldtteam.structurize.api.util.constant.Constants.GROUNDSTYLE_RELATIVE;
+
 /**
  * Window for a town hall name entry.
  */
@@ -63,6 +65,6 @@ public class WindowStructureNameEntry extends Window implements ButtonHandler
         }
 
         close();
-        Structurize.proxy.openBuildToolWindow(null);
+        Structurize.proxy.openBuildToolWindow(null, GROUNDSTYLE_RELATIVE);
     }
 }

--- a/src/main/java/com/ldtteam/structurize/items/ItemBuildTool.java
+++ b/src/main/java/com/ldtteam/structurize/items/ItemBuildTool.java
@@ -11,7 +11,7 @@ import net.minecraft.util.Hand;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.NotNull;
 
-import net.minecraft.item.Item.Properties;
+import static com.ldtteam.structurize.api.util.constant.Constants.GROUNDSTYLE_RELATIVE;
 
 /**
  * Class handling the buildTool item.
@@ -33,7 +33,7 @@ public class ItemBuildTool extends AbstractItemStructurize
     {
         if (context.getLevel().isClientSide)
         {
-            Structurize.proxy.openBuildToolWindow(context.getClickedPos().relative(context.getClickedFace()));
+            Structurize.proxy.openBuildToolWindow(context.getClickedPos().relative(context.getClickedFace()), GROUNDSTYLE_RELATIVE);
         }
         return ActionResultType.SUCCESS;
     }
@@ -46,7 +46,7 @@ public class ItemBuildTool extends AbstractItemStructurize
 
         if (worldIn.isClientSide)
         {
-            Structurize.proxy.openBuildToolWindow(null);
+            Structurize.proxy.openBuildToolWindow(null, GROUNDSTYLE_RELATIVE);
         }
 
         return new ActionResult<>(ActionResultType.SUCCESS, stack);

--- a/src/main/java/com/ldtteam/structurize/items/ItemBuildTool.java
+++ b/src/main/java/com/ldtteam/structurize/items/ItemBuildTool.java
@@ -33,7 +33,7 @@ public class ItemBuildTool extends AbstractItemStructurize
     {
         if (context.getLevel().isClientSide)
         {
-            Structurize.proxy.openBuildToolWindow(context.getClickedPos().relative(context.getHorizontalDirection()));
+            Structurize.proxy.openBuildToolWindow(context.getClickedPos().relative(context.getClickedFace()));
         }
         return ActionResultType.SUCCESS;
     }

--- a/src/main/java/com/ldtteam/structurize/items/ItemShapeTool.java
+++ b/src/main/java/com/ldtteam/structurize/items/ItemShapeTool.java
@@ -30,7 +30,7 @@ public class ItemShapeTool extends AbstractItemStructurize
     {
         if (context.getLevel().isClientSide)
         {
-            Structurize.proxy.openShapeToolWindow(context.getClickedPos().relative(context.getHorizontalDirection()));
+            Structurize.proxy.openShapeToolWindow(context.getClickedPos().relative(context.getClickedFace()));
         }
 
         return ActionResultType.SUCCESS;

--- a/src/main/java/com/ldtteam/structurize/proxy/ClientProxy.java
+++ b/src/main/java/com/ldtteam/structurize/proxy/ClientProxy.java
@@ -24,7 +24,7 @@ import net.minecraftforge.fml.server.ServerLifecycleHooks;
 public class ClientProxy implements IProxy
 {
     @Override
-    public void openBuildToolWindow(@Nullable final BlockPos pos)
+    public void openBuildToolWindow(@Nullable final BlockPos pos, final int groundstyle)
     {
         if (pos == null && Settings.instance.getActiveStructure() == null)
         {
@@ -37,7 +37,7 @@ public class ClientProxy implements IProxy
         }
 
         @Nullable
-        final WindowBuildTool window = new WindowBuildTool(pos);
+        final WindowBuildTool window = new WindowBuildTool(pos, groundstyle);
         window.open();
     }
 

--- a/src/main/java/com/ldtteam/structurize/proxy/IProxy.java
+++ b/src/main/java/com/ldtteam/structurize/proxy/IProxy.java
@@ -14,8 +14,9 @@ public interface IProxy
      * Opens a build tool window.
      *
      * @param pos coordinates.
+     * @param groundstyle one of the GROUNDSTYLE_ values.
      */
-    default void openBuildToolWindow(final BlockPos pos)
+    default void openBuildToolWindow(final BlockPos pos, final int groundstyle)
     {
     }
 


### PR DESCRIPTION
# Changes proposed in this pull request:
- Turns out Structurize and MineColonies used different (and inconsistent) methods to choose the initial block to anchor the build (and shape) tool previews at.  (Partly because they have to hook different events to do so.)  This changes Structurize to use the same choice as MineColonies.
- Specifically, the initial anchor is the block adjacent to the clicked face of the clicked block.  For the shape tool, this lets you build against a surface nicely.  For the build tool, the assumption is that most of the time you will be clicking the top face of the "ground" block anyway.  (And when the hut/anchor block is sitting directly on top of the ground, then this is already the correct location.)
- This also adjusts the treatment of schematics without a groundlevel tag to assume that the ground level is one block below the anchor (which agrees with the above assumption, and with the wiki docs for the groundlevel tag).  This is not true of all existing schematics, but there is no rule that would work universally.

Review please
