### PR TITLE
Remove hardcoded support for minecolonies huts

### DIFF
--- a/src/main/java/com/ldtteam/structurize/management/StructureName.java
+++ b/src/main/java/com/ldtteam/structurize/management/StructureName.java
@@ -109,10 +109,28 @@ public class StructureName
         {
             hut = schematic.split("\\d+")[0].toLowerCase(Locale.ROOT);
             section = Structures.SCHEMATICS_PREFIX;
-            if (HUTS.contains(hut)) {
+            if (HUTS.contains(hut))
+            {
                 section = hut;
-            } else {
-                hut = "";
+            }
+            else
+            {
+                try
+                {
+                    // This is for legacy minecolonies support
+                    if (ForgeRegistries.BLOCKS.getValue(new ResourceLocation(Constants.MINECOLONIES_MOD_ID, "blockhut" + hut)) == Blocks.AIR)
+                    {
+                        hut = "";
+                    }
+                    else
+                    {
+                        section = hut;
+                    }
+                }
+                catch (ResourceLocationException e)
+                {
+                    hut = "";
+                }
             }
         }
     }

--- a/src/main/java/com/ldtteam/structurize/management/StructureName.java
+++ b/src/main/java/com/ldtteam/structurize/management/StructureName.java
@@ -1,7 +1,7 @@
 package com.ldtteam.structurize.management;
 
-import com.ldtteam.structurize.util.LanguageHandler;
 import com.ldtteam.structurize.api.util.constant.Constants;
+import com.ldtteam.structurize.util.LanguageHandler;
 import net.minecraft.block.Blocks;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.ResourceLocationException;
@@ -9,6 +9,7 @@ import net.minecraftforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -20,7 +21,7 @@ import java.util.regex.Pattern;
  */
 public class StructureName
 {
-    public static List<String> HUTS = new ArrayList<>();
+    public static List<String> HUTS = Collections.synchronizedList(new ArrayList<>());
 
     private static final Pattern levelPattern              = Pattern.compile("[^0-9]+([0-9]+)$");
     private static final String  LOCALIZED_SCHEMATIC_LEVEL = "com.ldtteam.structurize.gui.buildtool.hut.level";

--- a/src/main/java/com/ldtteam/structurize/management/StructureName.java
+++ b/src/main/java/com/ldtteam/structurize/management/StructureName.java
@@ -108,19 +108,9 @@ public class StructureName
         {
             hut = schematic.split("\\d+")[0].toLowerCase(Locale.ROOT);
             section = Structures.SCHEMATICS_PREFIX;
-            try
-            {
-                if (ForgeRegistries.BLOCKS.getValue(new ResourceLocation(Constants.MINECOLONIES_MOD_ID, "blockhut" + hut)) != Blocks.AIR || HUTS.contains(hut))
-                {
-                    section = hut;
-                }
-                else
-                {
-                    hut = "";
-                }
-            }
-            catch (ResourceLocationException e)
-            {
+            if (HUTS.contains(hut)) {
+                section = hut;
+            } else {
                 hut = "";
             }
         }


### PR DESCRIPTION
These changes help mods other than minecolonies register their own huts.
Note: I was thinking that HUTS should be a list of ResourceLocations instead of Strings to allow differentiation between mods.

See  ldtteam/minecolonies#7659

# Changes proposed in this pull request:
- Makes StructureName.HUTS list synchronized to allow concurrent modification (such as multiple mods registering buildings during startup)
- Makes StructureName.init method search through the HUTS list first before looking for minecolonies huts through the registry.

Review please
