### PR TITLE
Fix scan tool not showing fluid placeholder blocks in the resource list.

### DIFF
--- a/src/main/java/com/ldtteam/structurize/placement/handlers/placement/PlacementHandlers.java
+++ b/src/main/java/com/ldtteam/structurize/placement/handlers/placement/PlacementHandlers.java
@@ -119,9 +119,19 @@ public final class PlacementHandlers
           boolean complete)
         {
             List<ItemStack> items = new ArrayList<>();
-            if (BlockUtils.getFluidForDimension(world).getBlock() == Blocks.LAVA)
+
+            if (complete)
             {
-                items.add(new ItemStack(Items.LAVA_BUCKET));
+                // for scan tool, show the actual placeholder block
+                items.add(new ItemStack(blockState.getBlock()));
+            }
+            else
+            {
+                // for build tool, water is free but lava needs a bucket
+                if (BlockUtils.getFluidForDimension(world).getBlock() == Blocks.LAVA)
+                {
+                    items.add(new ItemStack(Items.LAVA_BUCKET));
+                }
             }
 
             return items;


### PR DESCRIPTION
Closes [discord bug report](https://discord.com/channels/139070364159311872/672131611860402196/931441298592890920)

# Changes proposed in this pull request:
- Fluid placeholders are now shown in the scan tool's resource list, like the light and solid placeholders.

Review please

(This should probably be backported too.)