### PR TITLE
Fix crash from entity list icon missing

### DIFF
--- a/src/main/resources/assets/structurize/gui/windowscantool.xml
+++ b/src/main/resources/assets/structurize/gui/windowscantool.xml
@@ -36,8 +36,9 @@
 
     <list id="entities" size="200 100" pos="220 100">
         <box size="100% 30" linewidth="2">
+            <itemicon id="resourceIcon" size="16 16" pos="1 1"/>
             <label id="resourceName" size="100% 12" pos="0 1" color="white" wrap="true"/>
-            <buttonimage label="$(com.ldtteam.structurize.gui.scanTool.remove)" id="removeEntity" pos="0 13" size="86 17"
+            <buttonimage label="$(com.ldtteam.structurize.gui.scantool.remove)" id="removeEntity" pos="0 13" size="86 17"
                          source="structurize:textures/gui/builderhut/builder_button_medium.png" textcolor="black"/>
         </box>
     </list>

--- a/src/main/resources/assets/structurize/gui/windowscantool.xml
+++ b/src/main/resources/assets/structurize/gui/windowscantool.xml
@@ -33,12 +33,11 @@
         </box>
     </list>
 
-
-    <list id="entities" size="200 100" pos="220 100">
-        <box size="100% 30" linewidth="2">
+    <list id="entities" size="200 100" pos="220 100" childspacing="-1">
+        <box size="100% 30" linewidth="1">
             <itemicon id="resourceIcon" size="16 16" pos="1 1"/>
-            <label id="resourceName" size="100% 12" pos="0 1" color="white" wrap="true"/>
-            <buttonimage label="$(com.ldtteam.structurize.gui.scantool.remove)" id="removeEntity" pos="0 13" size="86 17"
+            <label id="resourceName" size="172 12" pos="19 1" color="white" wrap="true"/>
+            <buttonimage label="$(com.ldtteam.structurize.gui.scantool.remove)" id="removeEntity" pos="19 13" size="86 17"
                          source="structurize:textures/gui/builderhut/builder_button_medium.png" textcolor="black"/>
         </box>
     </list>


### PR DESCRIPTION
Closes #475

# Changes proposed in this pull request:
- Fix crash when entities present in scan area, introduced by dcdbf24 

Review please

1.16 is not affected by this; adding a resource icon to the entity list appears to have been introduced in 1.17 by f1e91288276.