### PR TITLE
Bans homicide (and suicide)

### DIFF
--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowScan.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowScan.java
@@ -25,7 +25,6 @@ import net.minecraft.util.Tuple;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.decoration.GlowItemFrame;
 import net.minecraft.world.entity.decoration.ItemFrame;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.vehicle.AbstractMinecart;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -345,7 +344,7 @@ public class WindowScan extends AbstractWindowSkeleton
                     for (final Entity entity : list)
                     {
                         if (!entities.containsKey(entity.getName().getString())
-                                && !(entity instanceof Player)
+                                && entity.getType().canSerialize()
                                 && (filter.isEmpty() || (entity.getName().getString().toLowerCase(Locale.US).contains(filter.toLowerCase(Locale.US))
                                     || (entity.toString().toLowerCase(Locale.US).contains(filter.toLowerCase(Locale.US))))))
                         {

--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowScan.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowScan.java
@@ -23,6 +23,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.util.Tuple;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.decoration.GlowItemFrame;
 import net.minecraft.world.entity.decoration.ItemFrame;
 import net.minecraft.world.entity.vehicle.AbstractMinecart;
@@ -343,8 +344,10 @@ public class WindowScan extends AbstractWindowSkeleton
 
                     for (final Entity entity : list)
                     {
+                        // LEASH_KNOT, while not directly serializable, still serializes as part of the mob
+                        // and drops a lead, so we should alert builders that it exists in the scan
                         if (!entities.containsKey(entity.getName().getString())
-                                && entity.getType().canSerialize()
+                                && (entity.getType().canSerialize() || entity.getType().equals(EntityType.LEASH_KNOT))
                                 && (filter.isEmpty() || (entity.getName().getString().toLowerCase(Locale.US).contains(filter.toLowerCase(Locale.US))
                                     || (entity.toString().toLowerCase(Locale.US).contains(filter.toLowerCase(Locale.US))))))
                         {

--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowScan.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowScan.java
@@ -25,6 +25,7 @@ import net.minecraft.util.Tuple;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.decoration.GlowItemFrame;
 import net.minecraft.world.entity.decoration.ItemFrame;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.vehicle.AbstractMinecart;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -344,6 +345,7 @@ public class WindowScan extends AbstractWindowSkeleton
                     for (final Entity entity : list)
                     {
                         if (!entities.containsKey(entity.getName().getString())
+                                && !(entity instanceof Player)
                                 && (filter.isEmpty() || (entity.getName().getString().toLowerCase(Locale.US).contains(filter.toLowerCase(Locale.US))
                                     || (entity.toString().toLowerCase(Locale.US).contains(filter.toLowerCase(Locale.US))))))
                         {


### PR DESCRIPTION
# Changes proposed in this pull request:
- Prevents players in creative mode from being able to delete other players (or themselves) for the crime of wandering into an active scan area.
    - (Also fixes it for a couple of other entity types, to match the [scan-time filter](https://github.com/ldtteam/Structurize/blob/30fb6a9c9633caf479130c934071551f04038734/src/main/java/com/ldtteam/structurize/blueprints/v1/BlueprintUtil.java#L123).  Though those are far less likely to be inside the scan area.)

Review please

Note that 1.16 has a slightly different [scan-time filter](https://github.com/ldtteam/Structurize/blob/88c4efa78b119dc14978d08e094515903cd85dc8/src/main/java/com/ldtteam/structures/blueprints/v1/BlueprintUtil.java#L125), but the effect is similar, so this may want to be backported.  (And perhaps the filter changed to match, although they're equivalent.)