### PR TITLE
Fixes to fake world

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -54,7 +54,8 @@ optiFineDevTweaker=2.6.5/aa_do_not_rename_OptiFineDevTweaker-2.6.5-all.jar
 optifineVersion=1.18.2_HD_U_H7
 # file name -> url map of shaders, other local shaders will get deleted, syntax: key|value;key|value;key|value ...
 shadersToUse=SEUS PTGI HRR 3.zip|https://www.patreon.com/file?h=60268558&i=9656012;\
-projectLUMA+-+v1.32.zip|https://media.forgecdn.net/files/2842/623/projectLUMA+-+v1.32.zip
+projectLUMA+-+v1.32.zip|https://media.forgecdn.net/files/2842/623/projectLUMA+-+v1.32.zip;\
+BSL_v8.1.02.2.zip|https://media.forgecdn.net/files/3752/138/BSL_v8.1.02.2.zip
 
 useDefaultTestSystem=false
 runtimeSourceSets=api;test;main

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,11 +10,11 @@ javaVersion=17
 useJavaToolChains=true
 
 #The currently running forge.
-forgeVersion=40.0.2
+forgeVersion=40.1.19
 #The minimal needed forge, as marked in metadata and curseforge.
-forgeMinVersion=40.0.2
-fmlRange=[38,)
-forgeRange=[40.0.2,)
+forgeMinVersion=40.1.0
+fmlRange=[40,)
+forgeRange=[40.1.0,)
 
 #The version for forge (dependency)
 exactMinecraftVersion=1.18.2
@@ -51,7 +51,7 @@ optifineMcJarPath=
 # stripped address from github releases eg. https://github.com/OpenCubicChunks/OptiFineDevTweaker/releases/download/ optiFineDevTweaker
 optiFineDevTweaker=2.6.5/aa_do_not_rename_OptiFineDevTweaker-2.6.5-all.jar
 # optifine version for use in https://optifine.net/download?f=OptiFine_ version .jar
-optifineVersion=1.18.1_HD_U_H4
+optifineVersion=1.18.2_HD_U_H7
 # file name -> url map of shaders, other local shaders will get deleted, syntax: key|value;key|value;key|value ...
 shadersToUse=SEUS PTGI HRR 3.zip|https://www.patreon.com/file?h=60268558&i=9656012;\
 projectLUMA+-+v1.32.zip|https://media.forgecdn.net/files/2842/623/projectLUMA+-+v1.32.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/ldtteam/structurize/blocks/ModBlocks.java
+++ b/src/main/java/com/ldtteam/structurize/blocks/ModBlocks.java
@@ -9,7 +9,6 @@ import com.ldtteam.structurize.items.ModItemGroups;
 import com.ldtteam.structurize.items.ModItems;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
-import net.minecraft.tags.Tag;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.CreativeModeTab;

--- a/src/main/java/com/ldtteam/structurize/blueprints/v1/Blueprint.java
+++ b/src/main/java/com/ldtteam/structurize/blueprints/v1/Blueprint.java
@@ -498,9 +498,9 @@ public class Blueprint
     private BlockPos findPrimaryBlockOffset()
     {
         final List<BlockInfo> list = getBlockInfoAsList().stream()
-                                       .filter(blockInfo -> blockInfo.getState().getBlock() instanceof IAnchorBlock
-                                                              || (blockInfo.hasTileEntityData() && blockInfo.getTileEntityData().contains(TAG_BLUEPRINTDATA)))
-            .collect(Collectors.toList());
+            .filter(blockInfo -> blockInfo.getState().getBlock() instanceof IAnchorBlock ||
+                (blockInfo.hasTileEntityData() && blockInfo.getTileEntityData().contains(TAG_BLUEPRINTDATA)))
+            .toList();
 
         if (list.size() != 1)
         {

--- a/src/main/java/com/ldtteam/structurize/client/BlueprintChunk.java
+++ b/src/main/java/com/ldtteam/structurize/client/BlueprintChunk.java
@@ -1,5 +1,7 @@
 package com.ldtteam.structurize.client;
 
+import com.ldtteam.structurize.helpers.Settings;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
@@ -380,7 +382,7 @@ public class BlueprintChunk extends LevelChunk
     @Override
     public int getLightEmission(BlockPos pos)
     {
-        return access.forceLightLevel() ? access.getOurLightLevel() : super.getLightEmission(pos);
+        return Settings.instance.forceLightLevel() ? Settings.instance.getOurLightLevel() : super.getLightEmission(pos);
     }
 
     @Override

--- a/src/main/java/com/ldtteam/structurize/client/BlueprintHandler.java
+++ b/src/main/java/com/ldtteam/structurize/client/BlueprintHandler.java
@@ -41,7 +41,6 @@ public final class BlueprintHandler
      *
      * @return a static instance of this class.
      */
-    @Deprecated // INTERNAL USE ONLY
     public static BlueprintHandler getInstance()
     {
         return ourInstance;

--- a/src/main/java/com/ldtteam/structurize/client/BlueprintRenderer.java
+++ b/src/main/java/com/ldtteam/structurize/client/BlueprintRenderer.java
@@ -86,7 +86,6 @@ public class BlueprintRenderer implements AutoCloseable
     private BlueprintRenderer(final BlueprintBlockAccess blockAccess)
     {
         this.blockAccess = blockAccess;
-        init();
     }
 
     /**
@@ -117,9 +116,7 @@ public class BlueprintRenderer implements AutoCloseable
         final PoseStack matrixStack = new PoseStack();
         final List<BlockInfo> blocks = blockAccess.getBlueprint().getBlockInfoAsList();
         final Map<RenderType, VertexBuffer> newVertexBuffers = blockVertexBuffersFactory.get();
-        final BlockState defaultFluidState = Minecraft.getInstance().level != null
-            ? BlockUtils.getFluidForDimension(Minecraft.getInstance().level)
-            : Blocks.WATER.defaultBlockState();
+        final BlockState defaultFluidState = BlockUtils.getFluidForDimension(Minecraft.getInstance().level);
 
         for (final RenderType renderType : RenderType.chunkBufferLayers())
         {
@@ -186,14 +183,15 @@ public class BlueprintRenderer implements AutoCloseable
         final long gameTime = mc.level.getGameTime();
     
         mc.getProfiler().push("struct_render_init");
-        if (Settings.instance.shouldRefresh())
+        final BlockPos anchorPos = pos.subtract(blockAccess.getBlueprint().getPrimaryBlockOffset());
+        blockAccess.setWorldPos(anchorPos);
+        if (Settings.instance.shouldRefresh() || vertexBuffers == null)
         {
             init();
         }
 
         mc.getProfiler().popPush("struct_render_prepare");
         final Vec3 viewPosition = mc.gameRenderer.getMainCamera().getPosition();
-        final BlockPos anchorPos = pos.subtract(blockAccess.getBlueprint().getPrimaryBlockOffset());
         final Vec3 realRenderRootVecd = Vec3.atLowerCornerOf(anchorPos).subtract(viewPosition);
         final Vector3f realRenderRootVecf = new Vector3f(realRenderRootVecd);
 

--- a/src/main/java/com/ldtteam/structurize/client/BlueprintRenderer.java
+++ b/src/main/java/com/ldtteam/structurize/client/BlueprintRenderer.java
@@ -103,6 +103,7 @@ public class BlueprintRenderer implements AutoCloseable
         }
     }
 
+    @SuppressWarnings("resource")
     private void init()
     {
         final Map<BlockPos, IModelData> teModelData = new HashMap<>();

--- a/src/main/java/com/ldtteam/structurize/client/StructureClientHandler.java
+++ b/src/main/java/com/ldtteam/structurize/client/StructureClientHandler.java
@@ -14,12 +14,6 @@ public final class StructureClientHandler
         throw new IllegalArgumentException("Utility class");
     }
 
-    @Deprecated // INTERNAL USE ONLY
-    public static void renderStructure(final Blueprint blueprint, final float partialTicks, final BlockPos pos, final PoseStack stack)
-    {
-        BlueprintHandler.getInstance().draw(blueprint, pos, stack, partialTicks);
-    }
-
     /**
      * Renders blueprint at single position.
      *
@@ -29,14 +23,8 @@ public final class StructureClientHandler
     public static void renderStructureAtPos(final Blueprint blueprint, final float partialTicks, final BlockPos pos, final PoseStack stack)
     {
         OptifineCompat.getInstance().preBlueprintDraw();
-        renderStructure(blueprint, partialTicks, pos, stack);
+        BlueprintHandler.getInstance().draw(blueprint, pos, stack, partialTicks);
         OptifineCompat.getInstance().postBlueprintDraw();
-    }
-
-    @Deprecated // INTERNAL USE ONLY
-    public static void renderStructure(final Blueprint blueprint, final float partialTicks, final List<BlockPos> points, final PoseStack stack)
-    {
-        BlueprintHandler.getInstance().drawAtListOfPositions(blueprint, points, stack, partialTicks);
     }
 
     /**
@@ -49,7 +37,7 @@ public final class StructureClientHandler
     public static void renderStructureAtPosList(final Blueprint blueprint, final float partialTicks, final List<BlockPos> points, final PoseStack stack)
     {
         OptifineCompat.getInstance().preBlueprintDraw();
-        renderStructure(blueprint, partialTicks, points, stack);
+        BlueprintHandler.getInstance().drawAtListOfPositions(blueprint, points, stack, partialTicks);
         OptifineCompat.getInstance().postBlueprintDraw();
     }
 }

--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowBuildTool.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowBuildTool.java
@@ -214,6 +214,7 @@ public class WindowBuildTool extends AbstractWindowSkeleton
         this.init(pos, 0, groundstyle);
     }
 
+    @SuppressWarnings("resource")
     private void init(final BlockPos pos, final int rot, final int groundstyle)
     {
         @Nullable
@@ -507,6 +508,7 @@ public class WindowBuildTool extends AbstractWindowSkeleton
      * Also updates state via {@link LSStructureDisplayerMessage}
      */
     @Override
+    @SuppressWarnings("resource")
     public void onClosed()
     {
         if (Settings.instance.getActiveStructure() != null)
@@ -930,6 +932,7 @@ public class WindowBuildTool extends AbstractWindowSkeleton
     /**
      * Changes the current structure.
      */
+    @SuppressWarnings("resource")
     public static void commonStructureUpdate()
     {
         final String sname = Settings.instance.getStructureName();
@@ -1149,6 +1152,7 @@ public class WindowBuildTool extends AbstractWindowSkeleton
      *
      * @return true if so.
      */
+    @SuppressWarnings("resource")
     public boolean hasPermission()
     {
         final boolean result = Minecraft.getInstance().player.isCreative();

--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowReplaceBlock.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowReplaceBlock.java
@@ -179,6 +179,7 @@ public class WindowReplaceBlock extends AbstractWindowSkeleton
         });
     }
 
+    @SuppressWarnings("resource")
     private void updateResources()
     {
         allItems.clear();
@@ -218,6 +219,7 @@ public class WindowReplaceBlock extends AbstractWindowSkeleton
         }
     }
 
+    @SuppressWarnings("resource")
     public void doneClicked(final Button button)
     {
         final ItemStack to = findPaneOfTypeByID("resourceIconTo", ItemIcon.class).getItem();

--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowScan.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowScan.java
@@ -213,6 +213,7 @@ public class WindowScan extends AbstractWindowSkeleton
     }
 
     @Override
+    @SuppressWarnings("resource")
     public void onOpened()
     {
         super.onOpened();
@@ -289,6 +290,7 @@ public class WindowScan extends AbstractWindowSkeleton
     /**
      * Clears and resets/updates all resources.
      */
+    @SuppressWarnings("resource")
     private void updateResources()
     {
         final BlockPos def = Minecraft.getInstance().player.blockPosition();
@@ -441,6 +443,7 @@ public class WindowScan extends AbstractWindowSkeleton
              * @param index the index of the row/list element.
              * @param rowPane the parent Pane for the row, containing the elements to update.
              */
+            @SuppressWarnings("resource")
             @Override
             public void updateElement(final int index, final Pane rowPane)
             {
@@ -494,6 +497,7 @@ public class WindowScan extends AbstractWindowSkeleton
              * @param rowPane the parent Pane for the row, containing the elements to update.
              */
             @Override
+            @SuppressWarnings("resource")
             public void updateElement(final int index, final Pane rowPane)
             {
                 final ItemStorage resource = tempRes.get(index);

--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowShapeTool.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowShapeTool.java
@@ -20,7 +20,6 @@ import com.ldtteam.structurize.util.LanguageHandler;
 import com.ldtteam.structurize.util.PlacementSettings;
 import com.ldtteam.structurize.util.StructureUtils;
 import net.minecraft.client.Minecraft;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Mirror;
@@ -344,22 +343,6 @@ public class WindowShapeTool extends AbstractWindowSkeleton
     }
 
     /**
-     * Ignore the blocks already in the world
-     */
-    private void replaceBlocksToggle()
-    {
-        final Button replaceButton = findPaneOfTypeByID(BUTTON_REPLACE, Button.class);
-        if (replaceButton.getTextAsString().equalsIgnoreCase(new TranslatableComponent("com.ldtteam.structurize.gui.shapetool.replace").getString()))
-        {
-            replaceButton.setText(new TranslatableComponent("com.ldtteam.structurize.gui.shapetool.ignore"));
-        }
-        else if (replaceButton.getTextAsString().equalsIgnoreCase(new TranslatableComponent("com.ldtteam.structurize.gui.shapetool.ignore").getString()))
-        {
-            replaceButton.setText(new TranslatableComponent("com.ldtteam.structurize.gui.shapetool.replace"));
-        }
-    }
-
-    /**
      * Toggle the hollow or solid inputShape
      */
     private void hollowShapeToggle()
@@ -470,6 +453,7 @@ public class WindowShapeTool extends AbstractWindowSkeleton
      * Sets up the buttons for either hut mode or decoration mode.
      */
     @Override
+    @SuppressWarnings("resource")
     public void onOpened()
     {
         if (!hasPermission())
@@ -496,6 +480,7 @@ public class WindowShapeTool extends AbstractWindowSkeleton
      *
      * @return true if so.
      */
+    @SuppressWarnings("resource")
     public boolean isCreative()
     {
         return Minecraft.getInstance().player.isCreative();

--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowTagTool.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowTagTool.java
@@ -91,6 +91,7 @@ public class WindowTagTool extends AbstractWindowSkeleton
     }
 
     @Override
+    @SuppressWarnings("resource")
     public void close()
     {
         super.close();

--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowUndoRedo.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowUndoRedo.java
@@ -10,6 +10,7 @@ import com.ldtteam.structurize.network.messages.OperationHistoryMessage;
 import com.ldtteam.structurize.network.messages.UndoRedoMessage;
 import com.ldtteam.structurize.util.TickedWorldOperation;
 import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.TextComponent;
 import net.minecraft.util.Tuple;
 import org.jetbrains.annotations.NotNull;
 
@@ -34,6 +35,7 @@ public class WindowUndoRedo extends AbstractWindowSkeleton
     /**
      * Constructor for the WindowUndo class.
      */
+    @SuppressWarnings("resource")
     public WindowUndoRedo()
     {
         super(Constants.MOD_ID + ":gui/windowundoredo.xml");
@@ -90,11 +92,12 @@ public class WindowUndoRedo extends AbstractWindowSkeleton
              * @param rowPane the parent Pane for the row, containing the elements to update.
              */
             @Override
+            @SuppressWarnings("resource")
             public void updateElement(final int index, @NotNull final Pane rowPane)
             {
                 final Tuple<String, Integer> resource = lastOperations.get(index);
                 final Text resourceLabel = rowPane.findPaneOfTypeByID("operationname", Text.class);
-                resourceLabel.setText(resource.getA());
+                resourceLabel.setText(new TextComponent(resource.getA()));
                 resourceLabel.setColors(WHITE);
 
                 if (resource.getA().indexOf(TickedWorldOperation.OperationType.UNDO.toString()) == 0)

--- a/src/main/java/com/ldtteam/structurize/commands/LinkSessionCommand.java
+++ b/src/main/java/com/ldtteam/structurize/commands/LinkSessionCommand.java
@@ -232,7 +232,6 @@ public class LinkSessionCommand
             return newLiteral(NAME).executes(s -> onExecute(s));
         }
 
-        // TODO: translations, wait for someone to cry first since it's pain to translate this :)
         private static int onExecute(final CommandContext<CommandSourceStack> command) throws CommandSyntaxException
         {
             final ServerPlayer sender = command.getSource().getPlayerOrException();

--- a/src/main/java/com/ldtteam/structurize/commands/arguments/MultipleStringArgument.java
+++ b/src/main/java/com/ldtteam/structurize/commands/arguments/MultipleStringArgument.java
@@ -61,6 +61,7 @@ public class MultipleStringArgument implements ArgumentType<String>
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <S> CompletableFuture<Suggestions> listSuggestions(final CommandContext<S> context, final SuggestionsBuilder builder)
     {
         if (context.getSource() instanceof ClientSuggestionProvider)

--- a/src/main/java/com/ldtteam/structurize/event/ClientEventSubscriber.java
+++ b/src/main/java/com/ldtteam/structurize/event/ClientEventSubscriber.java
@@ -5,7 +5,6 @@ import com.ldtteam.structurize.api.util.constant.Constants;
 import com.ldtteam.structurize.blocks.interfaces.IBlueprintDataProvider;
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
 import com.ldtteam.structurize.client.BlueprintHandler;
-import com.ldtteam.structurize.client.StructureClientHandler;
 import com.ldtteam.structurize.helpers.Settings;
 import com.ldtteam.structurize.items.ItemTagTool;
 import com.ldtteam.structurize.items.ModItems;
@@ -59,7 +58,7 @@ public class ClientEventSubscriber
             final BlockPos pos = Settings.instance.getPosition();
             final BlockPos posMinusOffset = pos.subtract(blueprint.getPrimaryBlockOffset());
 
-            StructureClientHandler.renderStructure(blueprint, partialTicks, pos, matrixStack);
+            BlueprintHandler.getInstance().draw(blueprint, pos, matrixStack, partialTicks);
             WorldRenderMacros.renderRedGlintLineBox(bufferSource, matrixStack, pos, pos, 0.02f);
             WorldRenderMacros.renderWhiteLineBox(bufferSource,
                 matrixStack,
@@ -120,6 +119,7 @@ public class ClientEventSubscriber
      * @param event the catched event.
      */
     @SubscribeEvent
+    @SuppressWarnings("resource")
     public static void onClientTickEvent(final ClientTickEvent event)
     {
         if (event.phase != Phase.END)

--- a/src/main/java/com/ldtteam/structurize/event/EventSubscriber.java
+++ b/src/main/java/com/ldtteam/structurize/event/EventSubscriber.java
@@ -14,17 +14,12 @@ import com.ldtteam.structurize.network.messages.StructurizeStylesMessage;
 import com.ldtteam.structurize.update.DomumOrnamentumUpdateHandler;
 import com.ldtteam.structurize.update.UpdateMode;
 import com.ldtteam.structurize.util.BackUpHelper;
-import com.ldtteam.structurize.util.BlockUtils;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.network.chat.ChatType;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraft.util.Tuple;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.Item;
 import net.minecraft.resources.ResourceLocation;
@@ -99,10 +94,10 @@ public class EventSubscriber
     @SubscribeEvent
     public static void onPlayerLogin(final PlayerEvent.PlayerLoggedInEvent event)
     {
-        if (event.getPlayer() instanceof ServerPlayer)
+        if (event.getPlayer() instanceof ServerPlayer serverPlayer)
         {
-            Network.getNetwork().sendToPlayer(new ServerUUIDMessage(), (ServerPlayer) event.getPlayer());
-            Network.getNetwork().sendToPlayer(new StructurizeStylesMessage(), (ServerPlayer) event.getPlayer());
+            Network.getNetwork().sendToPlayer(new ServerUUIDMessage(), serverPlayer);
+            Network.getNetwork().sendToPlayer(new StructurizeStylesMessage(), serverPlayer);
         }
     }
 
@@ -120,37 +115,6 @@ public class EventSubscriber
                 testDefaultBlocks(serverLevel);
             } */
         }
-    }
-
-    /**
-     * Tests for BlockUtils methods
-     * 
-     * @param level serverlevel
-     */
-    private static void testDefaultBlocks(final ServerLevel level)
-    {
-        if (level.getServer().getPlayerList().getPlayers().get(0).level != level)
-        {
-            return;
-        }
-        level.getServer()
-            .getPlayerList()
-            .broadcastMessage(new TextComponent(level.dimensionTypeRegistration().unwrapKey().get().toString()),
-                ChatType.SYSTEM,
-                level.getServer().getPlayerList().getPlayers().get(0).getUUID());
-        if (Minecraft.getInstance().hitResult != null && Minecraft.getInstance().hitResult instanceof BlockHitResult blockHitResult)
-        {
-            level.getServer()
-                .getPlayerList()
-                .broadcastMessage(new TextComponent("sub: " + BlockUtils.getSubstitutionBlockAtWorld(level, blockHitResult.getBlockPos(), null).toString()),
-                    ChatType.SYSTEM,
-                    level.getServer().getPlayerList().getPlayers().get(0).getUUID());
-        }
-        level.getServer()
-            .getPlayerList()
-            .broadcastMessage(new TextComponent("fluid: " + BlockUtils.getFluidForDimension(level).toString()),
-                ChatType.SYSTEM,
-                level.getServer().getPlayerList().getPlayers().get(0).getUUID());
     }
 
     @SubscribeEvent
@@ -252,7 +216,7 @@ public class EventSubscriber
         });
     }
 
-    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @SuppressWarnings({"ResultOfMethodCallIgnored","resource"})
     @SubscribeEvent
     public static void onGatherServerLevelCapabilities(final AttachCapabilitiesEvent<Level> attachCapabilitiesEvent)
     {

--- a/src/main/java/com/ldtteam/structurize/event/EventSubscriber.java
+++ b/src/main/java/com/ldtteam/structurize/event/EventSubscriber.java
@@ -110,10 +110,6 @@ public class EventSubscriber
             {
                 Manager.onWorldTick(serverLevel);
             }
-            /* if (event.world.getGameTime() % 200 == 0 && event.phase == Phase.END)
-            {
-                testDefaultBlocks(serverLevel);
-            } */
         }
     }
 

--- a/src/main/java/com/ldtteam/structurize/helpers/Settings.java
+++ b/src/main/java/com/ldtteam/structurize/helpers/Settings.java
@@ -324,6 +324,7 @@ public final class Settings implements INBTSerializable<CompoundTag>
      * @return The schematic we are currently rendering.
      */
     @Nullable
+    @SuppressWarnings("resource")
     public Blueprint getActiveStructure()
     {
         if (this.blueprint == null && this.structureName != null && !this.structureName.isEmpty() && pos != null)
@@ -343,6 +344,7 @@ public final class Settings implements INBTSerializable<CompoundTag>
      *
      * @param blueprint structure to render.
      */
+    @SuppressWarnings("resource")
     public void setActiveSchematic(final Blueprint blueprint)
     {
         if (blueprint == null)
@@ -434,6 +436,7 @@ public final class Settings implements INBTSerializable<CompoundTag>
      *
      * @param rotation the rotation to set.
      */
+    @SuppressWarnings("resource")
     public void setRotation(final int rotation)
     {
         int offset = rotation - this.rotation;
@@ -449,6 +452,7 @@ public final class Settings implements INBTSerializable<CompoundTag>
     /**
      * Makes the building mirror.
      */
+    @SuppressWarnings("resource")
     public void mirror()
     {
         if (blueprint == null)

--- a/src/main/java/com/ldtteam/structurize/helpers/Settings.java
+++ b/src/main/java/com/ldtteam/structurize/helpers/Settings.java
@@ -804,4 +804,20 @@ public final class Settings implements INBTSerializable<CompoundTag>
     {
         return renderLightPlaceholders;
     }
+
+    /**
+     * @return true when should use light level from {@link #getOurLightLevel()}
+     */
+    public boolean forceLightLevel()
+    {
+        return true;
+    }
+
+    /**
+     * @return static light level
+     */
+    public int getOurLightLevel()
+    {
+        return 15;
+    }
 }

--- a/src/main/java/com/ldtteam/structurize/items/ItemBuildTool.java
+++ b/src/main/java/com/ldtteam/structurize/items/ItemBuildTool.java
@@ -25,7 +25,8 @@ public class ItemBuildTool extends AbstractItemStructurize
         super("sceptergold", properties.stacksTo(1));
     }
 
-        @Override
+    @Override
+    @SuppressWarnings("resource")
     public InteractionResult useOn(final UseOnContext context)
     {
         if (context.getLevel().isClientSide)

--- a/src/main/java/com/ldtteam/structurize/items/ItemShapeTool.java
+++ b/src/main/java/com/ldtteam/structurize/items/ItemShapeTool.java
@@ -21,7 +21,8 @@ public class ItemShapeTool extends AbstractItemStructurize
         super("shapetool", properties.stacksTo(1));
     }
 
-        @Override
+    @Override
+    @SuppressWarnings("resource")
     public InteractionResult useOn(final UseOnContext context)
     {
         if (context.getLevel().isClientSide)

--- a/src/main/java/com/ldtteam/structurize/network/NetworkChannel.java
+++ b/src/main/java/com/ldtteam/structurize/network/NetworkChannel.java
@@ -4,9 +4,11 @@ import com.ldtteam.structurize.api.util.Log;
 import com.ldtteam.structurize.api.util.constant.Constants;
 import com.ldtteam.structurize.network.messages.*;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.network.NetworkEvent;
@@ -136,13 +138,10 @@ public class NetworkChannel
      * @param msg message to send
      * @param dim target dimension
      */
-    /*
-     * TODO: 1.16 waiting forge update
-     * public void sendToDimension(final IMessage msg, final DimensionType dim)
-     * {
-     * rawChannel.send(PacketDistributor.DIMENSION.with(() -> dim), msg);
-     * }
-     */
+    public void sendToDimension(final IMessage msg, final ResourceKey<Level> dim)
+    {
+        rawChannel.send(PacketDistributor.DIMENSION.with(() -> dim), msg);
+    }
 
     /**
      * Sends to everyone in circle made using given target point.

--- a/src/main/java/com/ldtteam/structurize/network/messages/RemoveEntityMessage.java
+++ b/src/main/java/com/ldtteam/structurize/network/messages/RemoveEntityMessage.java
@@ -2,7 +2,6 @@ package com.ldtteam.structurize.network.messages;
 
 import com.ldtteam.structurize.management.Manager;
 import com.ldtteam.structurize.util.ChangeStorage;
-import com.ldtteam.structurize.management.Manager;
 import com.ldtteam.structurize.util.TickedWorldOperation;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.network.FriendlyByteBuf;

--- a/src/main/java/com/ldtteam/structurize/network/messages/UpdateClientRender.java
+++ b/src/main/java/com/ldtteam/structurize/network/messages/UpdateClientRender.java
@@ -56,6 +56,7 @@ public class UpdateClientRender implements IMessage
         return LogicalSide.CLIENT;
     }
 
+    @SuppressWarnings("resource")
     @Override
     public void onExecute(final NetworkEvent.Context ctxIn, final boolean isLogicalServer)
     {

--- a/src/main/java/com/ldtteam/structurize/network/messages/UpdateScanToolMessage.java
+++ b/src/main/java/com/ldtteam/structurize/network/messages/UpdateScanToolMessage.java
@@ -43,6 +43,7 @@ public class UpdateScanToolMessage implements IMessage
      * @param from the start pos.
      * @param to the end pos.
      */
+    @SuppressWarnings("resource")
     public UpdateScanToolMessage(final BlockPos from, final BlockPos to)
     {
         final ItemStack stack = Minecraft.getInstance().player.getMainHandItem();

--- a/src/main/java/com/ldtteam/structurize/placement/StructurePlacer.java
+++ b/src/main/java/com/ldtteam/structurize/placement/StructurePlacer.java
@@ -296,7 +296,7 @@ public class StructurePlacer
 
         if (localState.getBlock() == ModBlocks.blockSolidSubstitution.get() && handler.fancyPlacement())
         {
-            localState = this.handler.getWorldGenBlock(worldPos, localPos.getY() + 1 < handler.getBluePrint().getSizeY()
+            localState = this.handler.getSolidBlockForPos(worldPos, localPos.getY() + 1 < handler.getBluePrint().getSizeY()
                 ? handler.getBluePrint().getBlockState(localPos.above())
                 : null);
         }
@@ -440,7 +440,7 @@ public class StructurePlacer
 
         if (localState.getBlock() == ModBlocks.blockSolidSubstitution.get() && handler.fancyPlacement())
         {
-            localState = this.handler.getWorldGenBlock(worldPos, localPos.getY() + 1 < handler.getBluePrint().getSizeY()
+            localState = this.handler.getSolidBlockForPos(worldPos, localPos.getY() + 1 < handler.getBluePrint().getSizeY()
                 ? handler.getBluePrint().getBlockState(localPos.above())
                 : null);
         }

--- a/src/main/java/com/ldtteam/structurize/placement/StructurePlacer.java
+++ b/src/main/java/com/ldtteam/structurize/placement/StructurePlacer.java
@@ -296,7 +296,9 @@ public class StructurePlacer
 
         if (localState.getBlock() == ModBlocks.blockSolidSubstitution.get() && handler.fancyPlacement())
         {
-            localState = this.handler.getSolidBlockForPos(worldPos);
+            localState = this.handler.getWorldGenBlock(worldPos, localPos.getY() + 1 < handler.getBluePrint().getSizeY()
+                ? handler.getBluePrint().getBlockState(localPos.above())
+                : null);
         }
         if (localState.getBlock() == ModBlocks.blockTagSubstitution.get() && handler.fancyPlacement())
         {
@@ -438,7 +440,9 @@ public class StructurePlacer
 
         if (localState.getBlock() == ModBlocks.blockSolidSubstitution.get() && handler.fancyPlacement())
         {
-            localState = this.handler.getSolidBlockForPos(worldPos);
+            localState = this.handler.getWorldGenBlock(worldPos, localPos.getY() + 1 < handler.getBluePrint().getSizeY()
+                ? handler.getBluePrint().getBlockState(localPos.above())
+                : null);
         }
         if (localState.getBlock() == ModBlocks.blockTagSubstitution.get() && handler.fancyPlacement())
         {

--- a/src/main/java/com/ldtteam/structurize/placement/handlers/placement/PlacementHandlers.java
+++ b/src/main/java/com/ldtteam/structurize/placement/handlers/placement/PlacementHandlers.java
@@ -244,7 +244,7 @@ public final class PlacementHandlers
                 for (int i = 0; i < 10; i++) // try up to ten blocks below for solid worldgen
                 { 
                     posBelow = posBelow.below();
-                    final BlockState possibleSupport = BlockUtils.getSubstitutionBlockAtWorld(world, posBelow, i == 0 ? blockState : null);
+                    final BlockState possibleSupport = BlockUtils.getWorldgenBlock(world, posBelow, i == 0 ? blockState : null);
                     if (possibleSupport.getMaterial().isSolid() && !(possibleSupport.getBlock() instanceof FallingBlock || possibleSupport.getBlock() instanceof Fallable))
                     {
                         supportBlockState = possibleSupport;
@@ -277,7 +277,7 @@ public final class PlacementHandlers
                 for (int i = 0; i < 10; i++) // try up to ten blocks below for solid worldgen
                 { 
                     posBelow = posBelow.below();
-                    final BlockState possibleSupport = BlockUtils.getSubstitutionBlockAtWorld(world, posBelow, i == 0 ? blockState : null);
+                    final BlockState possibleSupport = BlockUtils.getWorldgenBlock(world, posBelow, i == 0 ? blockState : null);
                     if (possibleSupport.getMaterial().isSolid() && !(possibleSupport.getBlock() instanceof FallingBlock || possibleSupport.getBlock() instanceof Fallable))
                     {
                         supportBlockState = possibleSupport;

--- a/src/main/java/com/ldtteam/structurize/placement/handlers/placement/PlacementHandlers.java
+++ b/src/main/java/com/ldtteam/structurize/placement/handlers/placement/PlacementHandlers.java
@@ -236,9 +236,22 @@ public final class PlacementHandlers
             final List<ItemStack> itemList = new ArrayList<>(getItemsFromTileEntity(tileEntityData, blockState));
             itemList.add(BlockUtils.getItemStackFromBlockState(blockState));
             itemList.removeIf(ItemStackUtils::isEmpty);
+
             if (!world.getBlockState(pos.below()).getMaterial().isSolid())
             {
-                itemList.addAll(getRequiredItemsForState(world, pos, BlockUtils.getSubstitutionBlockAtWorld(world, pos), tileEntityData, complete));
+                BlockPos posBelow = pos;
+                BlockState supportBlockState = Blocks.DIRT.defaultBlockState();
+                for (int i = 0; i < 10; i++) // try up to ten blocks below for solid worldgen
+                { 
+                    posBelow = posBelow.below();
+                    final BlockState possibleSupport = BlockUtils.getSubstitutionBlockAtWorld(world, posBelow, i == 0 ? blockState : null);
+                    if (possibleSupport.getMaterial().isSolid() && !(possibleSupport.getBlock() instanceof FallingBlock || possibleSupport.getBlock() instanceof Fallable))
+                    {
+                        supportBlockState = possibleSupport;
+                        break;
+                    }
+                }
+                itemList.addAll(getRequiredItemsForState(world, pos, supportBlockState, tileEntityData, complete));
             }
             return itemList;
         }
@@ -259,7 +272,19 @@ public final class PlacementHandlers
 
             if (!world.getBlockState(pos.below()).getMaterial().isSolid())
             {
-                world.setBlock(pos.below(), BlockUtils.getSubstitutionBlockAtWorld(world, pos), UPDATE_FLAG);
+                BlockPos posBelow = pos;
+                BlockState supportBlockState = Blocks.DIRT.defaultBlockState();
+                for (int i = 0; i < 10; i++) // try up to ten blocks below for solid worldgen
+                { 
+                    posBelow = posBelow.below();
+                    final BlockState possibleSupport = BlockUtils.getSubstitutionBlockAtWorld(world, posBelow, i == 0 ? blockState : null);
+                    if (possibleSupport.getMaterial().isSolid() && !(possibleSupport.getBlock() instanceof FallingBlock || possibleSupport.getBlock() instanceof Fallable))
+                    {
+                        supportBlockState = possibleSupport;
+                        break;
+                    }
+                }
+                world.setBlock(pos.below(), supportBlockState, UPDATE_FLAG);
             }
             if (!world.setBlock(pos, blockState, UPDATE_FLAG))
             {

--- a/src/main/java/com/ldtteam/structurize/placement/structure/CreativeStructureHandler.java
+++ b/src/main/java/com/ldtteam/structurize/placement/structure/CreativeStructureHandler.java
@@ -140,7 +140,7 @@ public class CreativeStructureHandler extends AbstractStructureHandler
     @Override
     public BlockState getSolidBlockForPos(final BlockPos worldPos)
     {
-        return BlockUtils.getSubstitutionBlockAtWorld(getWorld(), worldPos);
+        return BlockUtils.getSubstitutionBlockAtWorld(getWorld(), worldPos, null);
     }
 
     @Override

--- a/src/main/java/com/ldtteam/structurize/placement/structure/CreativeStructureHandler.java
+++ b/src/main/java/com/ldtteam/structurize/placement/structure/CreativeStructureHandler.java
@@ -142,4 +142,10 @@ public class CreativeStructureHandler extends AbstractStructureHandler
     {
         return BlockUtils.getSubstitutionBlockAtWorld(getWorld(), worldPos);
     }
+
+    @Override
+    public BlockState getWorldGenBlock(final BlockPos worldPos, final BlockState virtualBlockAbove)
+    {
+        return BlockUtils.getSubstitutionBlockAtWorld(getWorld(), worldPos, virtualBlockAbove);
+    }
 }

--- a/src/main/java/com/ldtteam/structurize/placement/structure/CreativeStructureHandler.java
+++ b/src/main/java/com/ldtteam/structurize/placement/structure/CreativeStructureHandler.java
@@ -144,7 +144,7 @@ public class CreativeStructureHandler extends AbstractStructureHandler
     }
 
     @Override
-    public BlockState getWorldGenBlock(final BlockPos worldPos, final BlockState virtualBlockAbove)
+    public BlockState getSolidBlockForPos(final BlockPos worldPos, final BlockState virtualBlockAbove)
     {
         return BlockUtils.getSubstitutionBlockAtWorld(getWorld(), worldPos, virtualBlockAbove);
     }

--- a/src/main/java/com/ldtteam/structurize/placement/structure/IStructureHandler.java
+++ b/src/main/java/com/ldtteam/structurize/placement/structure/IStructureHandler.java
@@ -252,5 +252,14 @@ public interface IStructureHandler
      * @param worldPos the world pos.
      * @return the right block (classically biome dependent).
      */
+    @Deprecated(forRemoval = true, since = "1.18.2")
     BlockState getSolidBlockForPos(BlockPos worldPos);
+
+    /**
+     * Get the worldgen block for given pos while using data from handler.
+     * @param worldPos          the world pos.
+     * @param virtualBlockAbove block that is gonna be place above given worldPos, null if unknown
+     * @return the worldgen block (classically biome dependent).
+     */
+    BlockState getWorldGenBlock(BlockPos worldPos, @Nullable BlockState virtualBlockAbove);
 }

--- a/src/main/java/com/ldtteam/structurize/placement/structure/IStructureHandler.java
+++ b/src/main/java/com/ldtteam/structurize/placement/structure/IStructureHandler.java
@@ -256,10 +256,10 @@ public interface IStructureHandler
     BlockState getSolidBlockForPos(BlockPos worldPos);
 
     /**
-     * Get the worldgen block for given pos while using data from handler.
+     * Get the solid worldgen block for given pos while using data from handler.
      * @param worldPos          the world pos.
      * @param virtualBlockAbove block that is gonna be place above given worldPos, null if unknown
-     * @return the worldgen block (classically biome dependent).
+     * @return the solid worldgen block (classically biome dependent).
      */
-    BlockState getWorldGenBlock(BlockPos worldPos, @Nullable BlockState virtualBlockAbove);
+    BlockState getSolidBlockForPos(BlockPos worldPos, @Nullable BlockState virtualBlockAbove);
 }

--- a/src/main/java/com/ldtteam/structurize/proxy/ClientProxy.java
+++ b/src/main/java/com/ldtteam/structurize/proxy/ClientProxy.java
@@ -9,9 +9,6 @@ import com.ldtteam.structurize.management.Manager;
 import com.ldtteam.structurize.management.Structures;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.server.ServerLifecycleHooks;
 import org.jetbrains.annotations.Nullable;
 
@@ -20,10 +17,10 @@ import java.io.File;
 /**
  * Client side proxy.
  */
-@Mod.EventBusSubscriber(Dist.CLIENT)
 public class ClientProxy implements IProxy
 {
     @Override
+    @SuppressWarnings("resource")
     public void openBuildToolWindow(@Nullable final BlockPos pos, final int groundstyle)
     {
         if (pos == null && Settings.instance.getActiveStructure() == null)
@@ -55,6 +52,7 @@ public class ClientProxy implements IProxy
     }
 
     @Override
+    @SuppressWarnings("resource")
     public File getSchematicsFolder()
     {
         if (ServerLifecycleHooks.getCurrentServer() == null)
@@ -81,11 +79,5 @@ public class ClientProxy implements IProxy
         }
 
         return worldSchematicFolder.getParentFile();
-    }
-
-    @Override
-    public BlockState getBlockStateFromWorld(final BlockPos pos)
-    {
-        return Minecraft.getInstance().level.getBlockState(pos);
     }
 }

--- a/src/main/java/com/ldtteam/structurize/proxy/IProxy.java
+++ b/src/main/java/com/ldtteam/structurize/proxy/IProxy.java
@@ -2,7 +2,6 @@ package com.ldtteam.structurize.proxy;
 
 import java.io.File;
 import org.jetbrains.annotations.Nullable;
-import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.core.BlockPos;
 
 /**
@@ -36,12 +35,6 @@ public interface IProxy
      */
     @Nullable
     default File getSchematicsFolder()
-    {
-        return null;
-    }
-
-    @Nullable
-    default BlockState getBlockStateFromWorld(final BlockPos pos)
     {
         return null;
     }

--- a/src/main/java/com/ldtteam/structurize/util/BlockUtils.java
+++ b/src/main/java/com/ldtteam/structurize/util/BlockUtils.java
@@ -144,6 +144,7 @@ public final class BlockUtils
      * @param  virtualBlockAbove block that is gonna be above this block during placement, null if unknown.
      * @return                   the BlockState of the filler block.
      */
+    @SuppressWarnings("resource")
     public static BlockState getSubstitutionBlockAtWorld(final Level world, final BlockPos location, @Nullable final BlockState virtualBlockAbove)
     {
         // TODO: rework to use whole information from blueprint
@@ -546,6 +547,7 @@ public final class BlockUtils
      * @param world the world of the dimension
      * @return the default blockstate for the default fluid
      */
+    @SuppressWarnings("resource")
     public static BlockState getFluidForDimension(Level world)
     {
         if (world instanceof ServerLevel serverLevel)

--- a/src/main/java/com/ldtteam/structurize/util/BlockUtils.java
+++ b/src/main/java/com/ldtteam/structurize/util/BlockUtils.java
@@ -559,7 +559,7 @@ public final class BlockUtils
                 return defaultFluid.getFluidState().isEmpty() ? Blocks.WATER.defaultBlockState() : defaultFluid;
             }
         }
-        return  world.dimensionType().ultraWarm() ? Blocks.LAVA.defaultBlockState() : Blocks.WATER.defaultBlockState();
+        return world == null || !world.dimensionType().ultraWarm() ? Blocks.WATER.defaultBlockState() : Blocks.LAVA.defaultBlockState();
     }
 
     /**

--- a/src/main/java/com/ldtteam/structurize/util/BlockUtils.java
+++ b/src/main/java/com/ldtteam/structurize/util/BlockUtils.java
@@ -207,12 +207,6 @@ public final class BlockUtils
                     }
                 }
 
-                /* serverLevel.getServer()
-                    .getPlayerList()
-                    .broadcastMessage(new TextComponent(String.format("f: %d s: %d t: %d", firstParam, secParam, thirdParam)),
-                        ChatType.SYSTEM,
-                        serverLevel.getServer().getPlayerList().getPlayers().get(0).getUUID()); */
-
                 secParam = locY - secParam + 1;
 
                 ctx.updateXZ(locX, locZ);

--- a/src/main/java/com/ldtteam/structurize/util/ClientStructureWrapper.java
+++ b/src/main/java/com/ldtteam/structurize/util/ClientStructureWrapper.java
@@ -36,6 +36,7 @@ public final class ClientStructureWrapper
      * @param CompoundNBT compound to store.
      * @param fileName       milli seconds for fileName.
      */
+    @SuppressWarnings("resource")
     public static void handleSaveScanMessage(final CompoundTag CompoundNBT, final String fileName)
     {
         final StructureName structureName =
@@ -57,15 +58,5 @@ public final class ClientStructureWrapper
 
         LanguageHandler.sendPlayerMessage(Minecraft.getInstance().player, "item.scepterSteel.scanSuccess", file);
         Settings.instance.setStructureName(structureName.toString());
-    }
-
-    /**
-     * Send a message to the player informing him that the schematic is too big.
-     *
-     * @param maxSize is the maximum size allowed in bytes.
-     */
-    public static void sendMessageSchematicTooBig(final int maxSize)
-    {
-        LanguageHandler.sendPlayerMessage(Minecraft.getInstance().player, "com.ldtteam.structurize.network.messages.schematicsavemessage.toobig", maxSize);
     }
 }

--- a/src/main/java/com/ldtteam/structurize/util/StructureLoadingUtils.java
+++ b/src/main/java/com/ldtteam/structurize/util/StructureLoadingUtils.java
@@ -322,6 +322,7 @@ public final class StructureLoadingUtils
      *
      * @return the folder for the cached schematics
      */
+    @SuppressWarnings("resource")
     public static List<File> getCachedSchematicsFolders()
     {
         final List<File> cachedSchems = new ArrayList<>();
@@ -352,6 +353,7 @@ public final class StructureLoadingUtils
      *
      * @return the client folder.
      */
+    @SuppressWarnings("resource")
     public static List<File> getClientSchematicsFolders()
     {
         final List<File> clientSchems = new ArrayList<>();

--- a/src/main/java/com/ldtteam/structurize/util/TickedWorldOperation.java
+++ b/src/main/java/com/ldtteam/structurize/util/TickedWorldOperation.java
@@ -369,23 +369,6 @@ public class TickedWorldOperation
     }
 
     /**
-     * Is this the correct block to remove it or replace it.
-     *
-     * @param replacementStack the world stack to check.
-     * @param worldState       the world state to check.
-     * @param compareStack     the comparison stack.
-     * @return true if so.
-     */
-    private static boolean correctBlockToRemoveOrReplace(final ItemStack replacementStack, final BlockState worldState, final ItemStack compareStack)
-    {
-        return (replacementStack != null && replacementStack.sameItem(compareStack)
-                  || (compareStack.getItem() instanceof BucketItem && ((BucketItem) compareStack.getItem()).getFluid() == worldState.getFluidState().getType())
-                  || (compareStack.getItem() instanceof BucketItem && worldState.getBlock() instanceof LiquidBlock
-                        && ((BucketItem) compareStack.getItem()).getFluid() == ((LiquidBlock) worldState.getBlock()).getFluid())
-                  || (compareStack.getItem() == Items.AIR && (worldState.getBlock() == Blocks.AIR)));
-    }
-
-    /**
      * Get the current change storage of this operation.
      *
      * @return the ChangeStorage object.

--- a/src/main/java/com/ldtteam/structurize/util/WorldRenderMacros.java
+++ b/src/main/java/com/ldtteam/structurize/util/WorldRenderMacros.java
@@ -927,7 +927,7 @@ public class WorldRenderMacros extends UiRenderMacros
                 .setLightmapState(NO_LIGHTMAP)
                 .setOverlayState(NO_OVERLAY)
                 .setLayeringState(NO_LAYERING)
-                .setOutputState(ITEM_ENTITY_TARGET)
+                .setOutputState(MAIN_TARGET)
                 .setTexturingState(DEFAULT_TEXTURING)
                 .setWriteMaskState(COLOR_WRITE)
                 .createCompositeState(false));
@@ -947,7 +947,7 @@ public class WorldRenderMacros extends UiRenderMacros
                 .setLightmapState(NO_LIGHTMAP)
                 .setOverlayState(NO_OVERLAY)
                 .setLayeringState(NO_LAYERING)
-                .setOutputState(ITEM_ENTITY_TARGET)
+                .setOutputState(MAIN_TARGET)
                 .setTexturingState(DEFAULT_TEXTURING)
                 .setWriteMaskState(COLOR_WRITE)
                 .createCompositeState(false));
@@ -967,7 +967,7 @@ public class WorldRenderMacros extends UiRenderMacros
                 .setLightmapState(NO_LIGHTMAP)
                 .setOverlayState(NO_OVERLAY)
                 .setLayeringState(NO_LAYERING)
-                .setOutputState(ITEM_ENTITY_TARGET)
+                .setOutputState(MAIN_TARGET)
                 .setTexturingState(DEFAULT_TEXTURING)
                 .setWriteMaskState(COLOR_WRITE)
                 .createCompositeState(false));
@@ -987,7 +987,7 @@ public class WorldRenderMacros extends UiRenderMacros
                 .setLightmapState(NO_LIGHTMAP)
                 .setOverlayState(NO_OVERLAY)
                 .setLayeringState(NO_LAYERING)
-                .setOutputState(ITEM_ENTITY_TARGET)
+                .setOutputState(MAIN_TARGET)
                 .setTexturingState(DEFAULT_TEXTURING)
                 .setWriteMaskState(COLOR_DEPTH_WRITE)
                 .createCompositeState(false));
@@ -1007,7 +1007,7 @@ public class WorldRenderMacros extends UiRenderMacros
                 .setLightmapState(NO_LIGHTMAP)
                 .setOverlayState(NO_OVERLAY)
                 .setLayeringState(NO_LAYERING)
-                .setOutputState(ITEM_ENTITY_TARGET)
+                .setOutputState(MAIN_TARGET)
                 .setTexturingState(DEFAULT_TEXTURING)
                 .setWriteMaskState(COLOR_DEPTH_WRITE)
                 .createCompositeState(false));
@@ -1027,7 +1027,7 @@ public class WorldRenderMacros extends UiRenderMacros
                 .setLightmapState(NO_LIGHTMAP)
                 .setOverlayState(NO_OVERLAY)
                 .setLayeringState(NO_LAYERING)
-                .setOutputState(ITEM_ENTITY_TARGET)
+                .setOutputState(MAIN_TARGET)
                 .setTexturingState(DEFAULT_TEXTURING)
                 .setWriteMaskState(COLOR_WRITE)
                 .createCompositeState(false));

--- a/src/main/java/com/ldtteam/structurize/util/WorldRenderMacros.java
+++ b/src/main/java/com/ldtteam/structurize/util/WorldRenderMacros.java
@@ -840,6 +840,7 @@ public class WorldRenderMacros extends UiRenderMacros
      * @param forceWhite              force white for no depth rendering
      * @param mergeEveryXListElements merge every X elements of text list using a tostring call
      */
+    @SuppressWarnings("resource")
     public static void renderDebugText(final BlockPos pos,
         final List<String> text,
         final PoseStack matrixStack,

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,22 +1,12 @@
-# BLOCKOUT
-public net.minecraft.world.entity.LivingEntity f_20890_ # dead
-public net.minecraft.client.gui.Font func_238415_a_(Lnet/minecraft/util/text/ITextProperties;FFILnet/minecraft/util/math/vector/Matrix4f;Z)I 
-public com.mojang.math.Matrix4f f_27606_ # m03
-public com.mojang.math.Matrix4f f_27610_ # m13
-public com.mojang.math.Matrix4f f_27614_ # m23
-public net.minecraft.network.chat.Style <init>(Lnet/minecraft/network/chat/TextColor;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lnet/minecraft/network/chat/ClickEvent;Lnet/minecraft/network/chat/HoverEvent;Ljava/lang/String;Lnet/minecraft/resources/ResourceLocation;)V
-
-
-# Structurize
 public net.minecraft.util.datafix.fixes.ChunkPalettedStorageFix f_15048_ # FLOWER_POT_MAP
 public net.minecraft.util.datafix.fixes.ChunkPalettedStorageFix f_15051_ # NOTE_BLOCK_MAP
 
-public net.minecraft.client.Minecraft f_90990_ # mainWindow
+# public net.minecraft.client.Minecraft f_90990_ # mainWindow
 
+# blueprint renderer
 public net.minecraft.client.Camera m_90581_(Lnet/minecraft/world/phys/Vec3;)V # setPostion
-public net.minecraft.client.gui.Font m_92726_(Lnet/minecraft/util/FormattedCharSequence;FFILcom/mojang/math/Matrix4f;Z)I # func_238415_a_
-public net.minecraft.world.level.biome.Biome f_47438_ #field_242424_k
 
+# DO upgrade from non DO world
 public net.minecraft.server.level.ChunkMap m_140427_(Lnet/minecraft/world/level/ChunkPos;)Lnet/minecraft/nbt/CompoundTag; #readChunk
 public net.minecraft.server.MinecraftServer f_129744_ #storageSource
 

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -19,3 +19,17 @@ public net.minecraft.world.level.biome.Biome f_47438_ #field_242424_k
 
 public net.minecraft.server.level.ChunkMap m_140427_(Lnet/minecraft/world/level/ChunkPos;)Lnet/minecraft/nbt/CompoundTag; #readChunk
 public net.minecraft.server.MinecraftServer f_129744_ #storageSource
+
+# world gen settings
+public net.minecraft.server.level.ChunkMap m_183719_()Lnet/minecraft/world/level/chunk/ChunkGenerator; # generator
+public net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator f_64318_ # settings
+public net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator f_188605_ # surfaceSystem
+public net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator f_188607_ # globalFluidPicker
+public net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator f_209104_ # router
+public net.minecraft.world.level.levelgen.SurfaceRules$Context
+public net.minecraft.world.level.levelgen.SurfaceRules$Context <init>(Lnet/minecraft/world/level/levelgen/SurfaceSystem;Lnet/minecraft/world/level/chunk/ChunkAccess;Lnet/minecraft/world/level/levelgen/NoiseChunk;Ljava/util/function/Function;Lnet/minecraft/core/Registry;Lnet/minecraft/world/level/levelgen/WorldGenerationContext;)V
+public net.minecraft.world.level.levelgen.SurfaceRules$Context m_189569_(II)V # updateXZ
+public net.minecraft.world.level.levelgen.SurfaceRules$Context m_189576_(IIIIII)V # updateY
+public net.minecraft.world.level.levelgen.SurfaceRules$SurfaceRule
+public net.minecraft.world.level.levelgen.Beardifier
+public net.minecraft.world.level.levelgen.Beardifier <init>(Lnet/minecraft/world/level/StructureFeatureManager;Lnet/minecraft/world/level/chunk/ChunkAccess;)V

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,8 +1,6 @@
 public net.minecraft.util.datafix.fixes.ChunkPalettedStorageFix f_15048_ # FLOWER_POT_MAP
 public net.minecraft.util.datafix.fixes.ChunkPalettedStorageFix f_15051_ # NOTE_BLOCK_MAP
 
-# public net.minecraft.client.Minecraft f_90990_ # mainWindow
-
 # blueprint renderer
 public net.minecraft.client.Camera m_90581_(Lnet/minecraft/world/phys/Vec3;)V # setPostion
 


### PR DESCRIPTION
Closes #504 
Progress towards #489 

# Changes proposed in this pull request:
- bump gradle and forge versions (min forge is recommended build)
- update fake world and chunk classes
- make substitution blocks smarter in c6155de8efa844e44afd801eca7b8c7b0c163d91
- preview will now respect surrounding biomes in full update (after rotate/mirror change)
- general cleanup removing most warnings (just 2 deprecations left)

Review please
