### PR TITLE
Add an entity icon control

### DIFF
--- a/src/main/java/com/ldtteam/blockout/Loader.java
+++ b/src/main/java/com/ldtteam/blockout/Loader.java
@@ -48,6 +48,7 @@ public final class Loader
         register("imagerepeat", ImageRepeatable::new);
         register("box", Box::new);
         register("itemicon", ItemIcon::new);
+        register("entityicon", EntityIcon::new);
         register("switch", SwitchView::new);
         register("dropdown", DropDownList::new);
         register("overlay", OverlayView::new);

--- a/src/main/java/com/ldtteam/blockout/Render.java
+++ b/src/main/java/com/ldtteam/blockout/Render.java
@@ -2,11 +2,18 @@ package com.ldtteam.blockout;
 
 import com.mojang.blaze3d.matrix.MatrixStack;
 import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.BufferBuilder;
+import net.minecraft.client.renderer.IRenderTypeBuffer;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.WorldVertexBufferUploader;
+import net.minecraft.client.renderer.entity.EntityRendererManager;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.util.math.vector.Matrix4f;
+import net.minecraft.util.math.vector.Quaternion;
+import net.minecraft.util.math.vector.Vector3f;
 import org.lwjgl.opengl.GL11;
 
 /**
@@ -83,5 +90,62 @@ public final class Render
 
         RenderSystem.enableTexture();
         RenderSystem.disableBlend();
+    }
+
+    /**
+     * Render an entity on a GUI.
+     * @param matrixStack matrix
+     * @param x horizontal center position
+     * @param y vertical bottom position
+     * @param scale scaling factor
+     * @param headYaw adjusts look rotation
+     * @param yaw adjusts body rotation
+     * @param pitch adjusts look rotation
+     * @param entity the entity to render
+     */
+    public static void drawEntity(final MatrixStack matrixStack, final int x, final int y, final double scale,
+                                  final float headYaw, final float yaw, final float pitch, final Entity entity)
+    {
+        final LivingEntity livingEntity = (entity instanceof LivingEntity) ? (LivingEntity) entity : null;
+        final Minecraft mc = Minecraft.getInstance();
+        if (entity.level == null) entity.level = mc.level;
+        matrixStack.pushPose();
+        matrixStack.translate((float) x, (float) y, 1050.0F);
+        matrixStack.scale(1.0F, 1.0F, -1.0F);
+        matrixStack.translate(0.0D, 0.0D, 1000.0D);
+        matrixStack.scale((float) scale, (float) scale, (float) scale);
+        final Quaternion pitchRotation = Vector3f.XP.rotationDegrees(pitch);
+        matrixStack.mulPose(Vector3f.ZP.rotationDegrees(180.0F));
+        matrixStack.mulPose(pitchRotation);
+        final float oldYawOffset = livingEntity == null ? 0F : livingEntity.yBodyRot;
+        final float oldPrevYawHead = livingEntity == null ? 0F : livingEntity.yHeadRotO;
+        final float oldYawHead = livingEntity == null ? 0F : livingEntity.yHeadRot;
+        final float oldYaw = entity.yRot;
+        final float oldPitch = entity.xRot;
+        entity.yRot = 180.0F + (float) headYaw;
+        entity.xRot = -pitch;
+        if (livingEntity != null)
+        {
+            livingEntity.yBodyRot = 180.0F + yaw;
+            livingEntity.yHeadRot = entity.yRot;
+            livingEntity.yHeadRotO = entity.yRot;
+        }
+        final EntityRendererManager entityrenderermanager = mc.getEntityRenderDispatcher();
+        pitchRotation.conj();
+        entityrenderermanager.overrideCameraOrientation(pitchRotation);
+        entityrenderermanager.setRenderShadow(false);
+        final IRenderTypeBuffer.Impl buffers = mc.renderBuffers().bufferSource();
+        RenderSystem.runAsFancy(() -> entityrenderermanager.render(entity, 0.0D, 0.0D, 0.0D, 0.0F, 1.0F, matrixStack, buffers, 0x00F000F0));
+        buffers.endBatch();
+        entityrenderermanager.setRenderShadow(true);
+        entity.yRot = oldYaw;
+        entity.xRot = oldPitch;
+        if (livingEntity != null)
+        {
+            livingEntity.yBodyRot = oldYawOffset;
+            livingEntity.yHeadRotO = oldPrevYawHead;
+            livingEntity.yHeadRot = oldYawHead;
+        }
+        matrixStack.popPose();
     }
 }

--- a/src/main/java/com/ldtteam/blockout/blockOut.xsd
+++ b/src/main/java/com/ldtteam/blockout/blockOut.xsd
@@ -124,6 +124,7 @@
             <xs:element name="gradient" type="gradientType"/>
             <xs:element name="box" type="boxType"/>
             <xs:element name="itemicon" type="itemIconType"/>
+            <xs:element name="entityicon" type="entityIconType"/>
             <xs:element name="switch" type="switchType"/>
             <xs:element name="dropdown" type="dropdownType"/>
             <xs:element name="treeview" type="treeViewType"/>
@@ -217,6 +218,19 @@
         <xs:complexContent>
             <xs:extension base="paneType">
                 <xs:attribute name="item" type="xs:string"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <!-- <entityicon> -->
+    <xs:complexType name="entityIconType">
+        <xs:complexContent>
+            <xs:extension base="paneType">
+                <xs:attribute name="entity" type="xs:string"/>
+                <xs:attribute name="count" type="xs:integer"/>
+                <xs:attribute name="yaw" type="xs:float"/>
+                <xs:attribute name="pitch" type="xs:float"/>
+                <xs:attribute name="head" type="xs:float"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>

--- a/src/main/java/com/ldtteam/blockout/controls/EntityIcon.java
+++ b/src/main/java/com/ldtteam/blockout/controls/EntityIcon.java
@@ -1,0 +1,152 @@
+package com.ldtteam.blockout.controls;
+
+import com.ldtteam.blockout.Pane;
+import com.ldtteam.blockout.PaneBuilders;
+import com.ldtteam.blockout.PaneParams;
+import com.ldtteam.blockout.Render;
+import com.mojang.blaze3d.matrix.MatrixStack;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.IRenderTypeBuffer;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraftforge.registries.ForgeRegistries;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Control to render an entity as an icon
+ */
+public class EntityIcon extends Pane
+{
+    @Nullable
+    private Entity entity;
+    private int count = 1;
+    private float yaw = 30;
+    private float pitch = -10;
+    private float headyaw = 0;
+
+    public EntityIcon()
+    {
+        super();
+    }
+
+    public EntityIcon(@NotNull PaneParams params)
+    {
+        super(params);
+
+        final String entityName = params.getString("entity");
+        if (entityName != null)
+        {
+            setEntity(new ResourceLocation(entityName));
+        }
+
+        this.count = params.getInteger("count", this.count);
+        this.yaw = params.getFloat("yaw", this.yaw);
+        this.pitch = params.getFloat("pitch", this.pitch);
+        this.headyaw = params.getFloat("head", this.headyaw);
+    }
+
+    public void setEntity(@NotNull ResourceLocation entityId)
+    {
+        final EntityType<?> entityType = ForgeRegistries.ENTITIES.getValue(entityId);
+        if (entityType != null)
+        {
+            setEntity(entityType);
+        }
+        else
+        {
+            resetEntity();
+        }
+    }
+
+    public void setEntity(@NotNull EntityType<?> type)
+    {
+        final Entity entity = type.create(Minecraft.getInstance().level);
+
+        if (entity != null)
+        {
+            setEntity(entity);
+        }
+        else
+        {
+            resetEntity();
+        }
+    }
+
+    public void setEntity(@NotNull Entity entity)
+    {
+        this.entity = entity;
+        this.setHoverPane(null);
+    }
+
+    public void resetEntity()
+    {
+        this.entity = null;
+        this.setHoverPane(null);
+    }
+
+    public void setCount(final int count)
+    {
+        this.count = count;
+    }
+
+    public void setYaw(final float yaw)
+    {
+        this.yaw = yaw;
+    }
+
+    public void setPitch(final float pitch)
+    {
+        this.pitch = pitch;
+    }
+
+    @Override
+    public void drawSelf(final MatrixStack ms, final double mx, final double my)
+    {
+        if (this.entity != null)
+        {
+            ms.pushPose();
+            ms.translate(x, y, -50);
+
+            final AxisAlignedBB bb = this.entity.getBoundingBox();
+            final float scale = (float) (getHeight() / bb.getYsize() / 1.5);
+            final int cx = (getWidth() / 2);
+            final int by = getHeight();
+            final int offsetY = 2;
+            Render.drawEntity(ms, cx, by - offsetY, scale, this.headyaw, this.yaw, this.pitch, this.entity);
+
+            if (this.count != 1)
+            {
+                String s = String.valueOf(this.count);
+                ms.translate(getWidth(), getHeight(), 100.0D);
+                ms.scale(0.75F, 0.75F, 0.75F);
+                IRenderTypeBuffer.Impl buffer = IRenderTypeBuffer.immediate(Tessellator.getInstance().getBuilder());
+                mc.font.drawInBatch(s,
+                        (float) (-4 - mc.font.width(s)),
+                        (float) (-mc.font.lineHeight),
+                        16777215,
+                        true,
+                        ms.last().pose(),
+                        buffer,
+                        false,
+                        0,
+                        15728880);
+                buffer.endBatch();
+            }
+
+            ms.popPose();
+        }
+    }
+
+    @Override
+    public void onUpdate()
+    {
+        if (this.onHover == null && this.entity != null)
+        {
+            PaneBuilders.tooltipBuilder().hoverPane(this).build().setText(this.entity.getDisplayName());
+        }
+    }
+}

--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowScan.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowScan.java
@@ -2,10 +2,7 @@ package com.ldtteam.structurize.client.gui;
 
 import com.ldtteam.blockout.Color;
 import com.ldtteam.blockout.Pane;
-import com.ldtteam.blockout.controls.Button;
-import com.ldtteam.blockout.controls.ItemIcon;
-import com.ldtteam.blockout.controls.Text;
-import com.ldtteam.blockout.controls.TextField;
+import com.ldtteam.blockout.controls.*;
 import com.ldtteam.blockout.views.ScrollingList;
 import com.ldtteam.structures.helpers.Settings;
 import com.ldtteam.structurize.Network;
@@ -453,6 +450,7 @@ public class WindowScan extends AbstractWindowSkeleton
             public void updateElement(final int index, @NotNull final Pane rowPane)
             {
                 rowPane.findPaneOfTypeByID(RESOURCE_NAME, Text.class).setText((IFormattableTextComponent) tempEntities.get(index).getName());
+                rowPane.findPaneOfTypeByID(RESOURCE_ICON, EntityIcon.class).setEntity(tempEntities.get(index));
                 if (!Minecraft.getInstance().player.isCreative())
                 {
                     rowPane.findPaneOfTypeByID(BUTTON_REMOVE_ENTITY, Button.class).hide();

--- a/src/main/resources/assets/structurize/gui/windowscantool.xml
+++ b/src/main/resources/assets/structurize/gui/windowscantool.xml
@@ -36,8 +36,9 @@
 
     <list id="entities" size="200 100" pos="220 100">
         <box size="100% 30" linewidth="2">
-            <label id="resourceName" size="100% 12" pos="0 1" color="white" wrap="true"/>
-            <buttonimage label="$(com.ldtteam.structurize.gui.scanTool.remove)" id="removeEntity" pos="0 13" size="86 17"
+            <entityicon id="resourceIcon" size="24 24" pos="1 4"/>
+            <label id="resourceName" size="166 12" pos="28 1" color="white" wrap="true"/>
+            <buttonimage label="$(com.ldtteam.structurize.gui.scanTool.remove)" id="removeEntity" pos="28 13" size="86 17"
                          source="structurize:textures/gui/builderhut/builder_button_medium.png" textcolor="black"/>
         </box>
     </list>


### PR DESCRIPTION
# Changes proposed in this pull request:
- Adds an `<entityicon>` control to blockout
- Uses that control in the scan tool UI
    ![image](https://user-images.githubusercontent.com/539951/170966953-ccf69681-d680-4d51-b6af-9e66548d1f59.png)

Review please

Items are a bit wibbly, and don't stay in their lane, but I don't think that's entirely a bad thing.
The entity rendering code is based on the JEI worker rendering from MineColonies, but with more auto-scaling and support for more entity types.