### PR TITLE
Fix tooltips going missing

### DIFF
--- a/src/main/java/com/ldtteam/blockout/Pane.java
+++ b/src/main/java/com/ldtteam/blockout/Pane.java
@@ -91,7 +91,7 @@ public class Pane extends AbstractGui
         visible = params.getBoolean("visible", visible);
         enabled = params.getBoolean("enabled", enabled);
         onHoverId = params.getString("onHoverId", onHoverId);
-        toolTipLines = params.getMultilineText("tooltip", toolTipLines);
+        toolTipLines = new ArrayList<>(params.getMultilineText("tooltip", toolTipLines));
     }
 
     /**

--- a/src/main/java/com/ldtteam/blockout/Pane.java
+++ b/src/main/java/com/ldtteam/blockout/Pane.java
@@ -56,7 +56,8 @@ public class Pane extends AbstractGui
      * Should be only used during drawing methods. Outside drawing scope value may be outdated.
      */
     protected boolean wasCursorInPane = false;
-    private List<IFormattableTextComponent> toolTipLines = new ArrayList<>();
+    @Nullable
+    private List<IFormattableTextComponent> toolTipLines = null;
 
     /**
      * Default constructor.
@@ -91,7 +92,7 @@ public class Pane extends AbstractGui
         visible = params.getBoolean("visible", visible);
         enabled = params.getBoolean("enabled", enabled);
         onHoverId = params.getString("onHoverId", onHoverId);
-        toolTipLines = new ArrayList<>(params.getMultilineText("tooltip", toolTipLines));
+        toolTipLines = params.getMultilineText("tooltip", toolTipLines);
     }
 
     /**
@@ -497,11 +498,11 @@ public class Pane extends AbstractGui
         window = w;
 
         // can't gen tooltip from xml until first window is set
-        if (!toolTipLines.isEmpty())
+        if (toolTipLines != null && !toolTipLines.isEmpty())
         {
             final TooltipBuilder ttBuilder = PaneBuilders.tooltipBuilder().hoverPane(this);
             toolTipLines.forEach(ttBuilder::appendNL);
-            toolTipLines.clear(); // do not regen it when window has changed (unlikely to happen) cuz onHover might have changed
+            toolTipLines = null; // do not regen it when window has changed (unlikely to happen) cuz onHover might have changed
             onHover = ttBuilder.build();
         }
 


### PR DESCRIPTION
# Changes proposed in this pull request:
- Fixes tooltips only occasionally working

Review please

The issue is that the array directly returned is cached (for a certain number of open windows), but is then also modified when the window is shown:
https://github.com/ldtteam/Structurize/blob/8e8cb55dca9a6b14ef9b80698170143e7e3a8b6a/src/main/java/com/ldtteam/blockout/Pane.java#L504

The net result is that the tooltip (when loaded from the xml, rather than being set programmatically) works exactly once on first load, then doesn't work again until either an F3+T reload is triggered or enough other windows are shown that it gets evicted from the cache and has to reload from XML.

This bug will likely affect BlockUI as well, since it has the same code.  Although I have not recently retested this and I do vaguely recall it behaving better the last time I did, but perhaps I was overlooking the cache effect.