### PR TITLE
Massive hack to scan entities, at least it works

### DIFF
--- a/src/main/java/com/ldtteam/structurize/blueprints/v1/BlueprintUtil.java
+++ b/src/main/java/com/ldtteam/structurize/blueprints/v1/BlueprintUtil.java
@@ -119,7 +119,7 @@ public class BlueprintUtil
                 {
                     continue;
                 }
-                entitiesTag.add(entity.serializeNBT().copy());
+                entitiesTag.add(entity.serializeNBT());
             }
 
             world.entityManager.permanentStorage.flush(false);

--- a/src/main/java/com/ldtteam/structurize/blueprints/v1/BlueprintUtil.java
+++ b/src/main/java/com/ldtteam/structurize/blueprints/v1/BlueprintUtil.java
@@ -119,7 +119,7 @@ public class BlueprintUtil
                 {
                     continue;
                 }
-                entitiesTag.add(entity.serializeNBT());
+                entitiesTag.add(entity.serializeNBT().copy());
             }
 
             world.entityManager.permanentStorage.flush(false);
@@ -147,7 +147,7 @@ public class BlueprintUtil
                                     final Vec3 posVec = new Vec3(posList.getDouble(0), posList.getDouble(1), posList.getDouble(2));
                                     if (area.contains(posVec))
                                     {
-                                        entitiesTag.add(entityCompound);
+                                        entitiesTag.add(entityCompound.copy());
                                     }
                                 }
                             }

--- a/src/main/java/com/ldtteam/structurize/blueprints/v1/BlueprintUtil.java
+++ b/src/main/java/com/ldtteam/structurize/blueprints/v1/BlueprintUtil.java
@@ -3,19 +3,20 @@ package com.ldtteam.structurize.blueprints.v1;
 import com.ldtteam.structurize.api.util.BlockPosUtil;
 import com.ldtteam.structurize.api.util.Log;
 import com.ldtteam.structurize.blockentities.interfaces.IBlueprintDataProviderBE;
+import net.minecraft.core.SectionPos;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.decoration.HangingEntity;
 import net.minecraft.nbt.*;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.SharedConstants;
 import net.minecraft.util.datafix.fixes.References;
 import net.minecraft.util.datafix.fixes.ChunkPalettedStorageFix;
+import net.minecraft.world.level.chunk.storage.EntityStorage;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.phys.Vec3;
-import net.minecraft.world.level.Level;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraftforge.fml.ModList;
 import org.apache.logging.log4j.LogManager;
@@ -52,7 +53,7 @@ public class BlueprintUtil
      * @return the generated Blueprint
      */
     public static Blueprint createBlueprint(
-      Level world,
+      ServerLevel world,
       BlockPos pos,
       final boolean saveEntities,
       short sizeX,
@@ -109,43 +110,82 @@ public class BlueprintUtil
         final CompoundTag[] tes = tileEntities.toArray(new CompoundTag[0]);
 
         final List<CompoundTag> entitiesTag = new ArrayList<>();
-
-        List<Entity> entities = new ArrayList<>();
+        final AABB area = new AABB(pos.getX(), pos.getY(), pos.getZ(), pos.getX() + sizeX, pos.getY() + sizeY, pos.getZ() + sizeZ);
         if (saveEntities)
         {
-            entities = world.getEntities(null,
-              new AABB(pos.getX(), pos.getY(), pos.getZ(), pos.getX() + sizeX, pos.getY() + sizeY, pos.getZ() + sizeZ));
-        }
-
-        for (final Entity entity : entities)
-        {
-            if (!entity.getType().canSerialize())
+            for (final Entity entity : world.getEntities(null, area))
             {
-                continue;
+                if (!entity.getType().canSerialize())
+                {
+                    continue;
+                }
+                entitiesTag.add(entity.serializeNBT());
             }
 
-            final Vec3 oldPos = entity.position();
-            final CompoundTag entityTag = entity.serializeNBT();
+            world.entityManager.permanentStorage.flush(false);
+            for (int x = SectionPos.blockToSectionCoord(pos.getX()); x <= SectionPos.blockToSectionCoord(pos.getX() + sizeX); x++)
+            {
+                for (int z = SectionPos.blockToSectionCoord(pos.getZ()); z <= SectionPos.blockToSectionCoord(pos.getZ() + sizeZ); z++)
+                {
+                    if (!world.entityManager.areEntitiesLoaded(new ChunkPos(x, z).toLong()))
+                    {
+                        try
+                        {
+                            final CompoundTag compoundTag = ((EntityStorage) world.entityManager.permanentStorage).worker.load(new ChunkPos(x, z));
+                            if (compoundTag == null)
+                            {
+                                continue;
+                            }
+
+                            final ListTag tagList = compoundTag.getList("Entities", CompoundTag.TAG_COMPOUND);
+                            for (int i = 0; i < tagList.size(); i++)
+                            {
+                                final CompoundTag entityCompound = tagList.getCompound(i);
+                                if (entityCompound.contains("Pos"))
+                                {
+                                    final ListTag posList = entityCompound.getList("Pos", CompoundTag.TAG_DOUBLE);
+                                    final Vec3 posVec = new Vec3(posList.getDouble(0), posList.getDouble(1), posList.getDouble(2));
+                                    if (area.contains(posVec))
+                                    {
+                                        entitiesTag.add(entityCompound);
+                                    }
+                                }
+                            }
+                        }
+                        catch (IOException e)
+                        {
+                            e.printStackTrace();
+                        }
+                    }
+                }
+            }
+        }
+
+        final List<CompoundTag> finalEntitiesTag = new ArrayList<>();
+
+        for (final CompoundTag entity : entitiesTag)
+        {
+            final ListTag posListTag = entity.getList("Pos", CompoundTag.TAG_DOUBLE);
+            final Vec3 oldPos = new Vec3(posListTag.getDouble(0), posListTag.getDouble(1), posListTag.getDouble(2));
 
             final ListTag posList = new ListTag();
             posList.add(DoubleTag.valueOf(oldPos.x - pos.getX()));
             posList.add(DoubleTag.valueOf(oldPos.y - pos.getY()));
             posList.add(DoubleTag.valueOf(oldPos.z - pos.getZ()));
 
-            BlockPos entityPos = entity.blockPosition();
-            if (entity instanceof HangingEntity)
+            entity.put("Pos", posList);
+            if (entity.contains("TileX"))
             {
-                entityPos = ((HangingEntity) entity).getPos();
+                entity.put("TileX", IntTag.valueOf(entity.getInt("TileX") - pos.getX()));
+                entity.put("TileY", IntTag.valueOf(entity.getInt("TileY") - pos.getY()));
+                entity.put("TileZ", IntTag.valueOf(entity.getInt("TileZ") - pos.getZ()));
             }
-            entityTag.put("Pos", posList);
-            entityTag.put("TileX", IntTag.valueOf(entityPos.getX() - pos.getX()));
-            entityTag.put("TileY", IntTag.valueOf(entityPos.getY() - pos.getY()));
-            entityTag.put("TileZ", IntTag.valueOf(entityPos.getZ() - pos.getZ()));
-            entitiesTag.add(entityTag);
+
+            finalEntitiesTag.add(entity);
         }
 
         final Blueprint schem = new Blueprint(sizeX, sizeY, sizeZ, (short) pallete.size(), pallete, structure, tes, requiredMods);
-        schem.setEntities(entitiesTag.toArray(new CompoundTag[0]));
+        schem.setEntities(finalEntitiesTag.toArray(new CompoundTag[0]));
 
         if (anchorPos.isPresent())
         {

--- a/src/main/java/com/ldtteam/structurize/items/ItemScanTool.java
+++ b/src/main/java/com/ldtteam/structurize/items/ItemScanTool.java
@@ -12,6 +12,7 @@ import com.ldtteam.structurize.storage.rendering.RenderingCache;
 import com.ldtteam.structurize.storage.rendering.types.BoxPreviewData;
 import com.ldtteam.structurize.util.BlockInfo;
 import com.ldtteam.structurize.util.LanguageHandler;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.server.level.ServerPlayer;
@@ -186,7 +187,7 @@ public class ItemScanTool extends AbstractItemWithPosSelector
             fileName+= ".blueprint";
         }
 
-        final Blueprint bp = BlueprintUtil.createBlueprint(world, blockpos, saveEntities, (short) size.getX(), (short) size.getY(), (short) size.getZ(), fileName, anchorPos);
+        final Blueprint bp = BlueprintUtil.createBlueprint((ServerLevel) world, blockpos, saveEntities, (short) size.getX(), (short) size.getY(), (short) size.getZ(), fileName, anchorPos);
 
         if (!anchorPos.isPresent() && bp.getPrimaryBlockOffset().equals(new BlockPos(bp.getSizeX() / 2, 0, bp.getSizeZ() / 2)))
         {

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -21,3 +21,7 @@ public net.minecraft.world.level.levelgen.SurfaceRules$Context m_189576_(IIIIII)
 public net.minecraft.world.level.levelgen.SurfaceRules$SurfaceRule
 public net.minecraft.world.level.levelgen.Beardifier
 public net.minecraft.world.level.levelgen.Beardifier <init>(Lnet/minecraft/world/level/StructureFeatureManager;Lnet/minecraft/world/level/chunk/ChunkAccess;)V
+
+public net.minecraft.server.level.ServerLevel f_143244_ # entityManager
+public net.minecraft.world.level.entity.PersistentEntitySectionManager f_157493_ # permanentStorage
+public net.minecraft.world.level.chunk.storage.EntityStorage f_156539_


### PR DESCRIPTION

# Changes proposed in this pull request:
- This is a massive hack to allow scanning entities that are in unloaded chunks.
- I tested this several times in different combinations.
- I believe, that as of the current system that's the best we can do.
- In the future we might want to think about alternatives that are easier to maintain like:

-- Not supporting scanning in unloaded chunks at all
-- Async scanning (chunk load the area, hand it to a ticker that waits properly for the entities to be loaded)
-- etc


