### PR TITLE
Fixes the new build/scan tool schematic names

### DIFF
--- a/src/main/java/com/ldtteam/structurize/blueprints/v1/BlueprintUtil.java
+++ b/src/main/java/com/ldtteam/structurize/blueprints/v1/BlueprintUtil.java
@@ -19,6 +19,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.registries.ForgeRegistries;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.logging.log4j.LogManager;
 
 import java.io.File;
@@ -163,7 +164,7 @@ public class BlueprintUtil
 
             if (name != null)
             {
-                final String fileName = new File(name).getName();
+                final String fileName = FilenameUtils.getBaseName(name);
                 blueprintData.putString(TAG_SCHEMATIC_NAME, fileName);
                 ((IBlueprintDataProviderBE) tile).setSchematicName(fileName);
             }

--- a/src/main/java/com/ldtteam/structurize/placement/structure/AbstractStructureHandler.java
+++ b/src/main/java/com/ldtteam/structurize/placement/structure/AbstractStructureHandler.java
@@ -88,7 +88,7 @@ public abstract class AbstractStructureHandler implements IStructureHandler
         {
             if (getProgressPosInWorld(pos).equals(worldPos))
             {
-                ((IBlueprintDataProviderBE) be).setBlueprintPath(StructurePacks.getStructurePack(getBluePrint().getPackName()).getSubPath(getBluePrint().getFilePath().resolve(getBluePrint().getFileName() + ".blueprint")));
+                ((IBlueprintDataProviderBE) be).setBlueprintPath(StructurePacks.getStructurePack(getBluePrint().getPackName()).getSubPath(getBluePrint().getFilePath().resolve(getBluePrint().getFileName())));
             }
             ((IBlueprintDataProviderBE) be).setPackName(getBluePrint().getPackName());
         }


### PR DESCRIPTION
# Changes proposed in this pull request:
- Stops the scan tool including `.blueprint` in the schematic name, which should make new build tool scans compatible with the old build tool again.

Review please

I wasn't able to test this with MineColonies, since the only branch I could find for that was 1.18 rather than 1.19.  But it seems to work ok with Structurize alone.  This also might not "fix" any existing schematics from that branch -- that _could_ be done, but would be quite messy, so it would be better to just fix the schematic files instead.

Related existing caveat: when running the game on Windows it saves backslashes in the schematic path NBT, which is contrary to how the game stores datapack paths etc (forward slashes only) and might potentially cause trouble if the world is moved to a linux server at some point... (I didn't fix this, but it possibly should be.)