### PR TITLE
Respect groundlevel tags

### DIFF
--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowExtendedBuildTool.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowExtendedBuildTool.java
@@ -1022,6 +1022,7 @@ public class WindowExtendedBuildTool extends AbstractBlueprintManipulationWindow
                 final Blueprint blueprint = mapping.values().iterator().next().get(0);
                 findPaneOfTypeByID("tree", Text.class).setText(Component.literal(structurePack.getName() + "/" + depth + "/" + blueprint.getFileName()).setStyle(Style.EMPTY.withBold(true)));
                 RenderingCache.getOrCreateBlueprintPreviewData("blueprint").setBlueprint(blueprint);
+                adjustToGroundOffset();
                 return;
             }
 
@@ -1041,6 +1042,7 @@ public class WindowExtendedBuildTool extends AbstractBlueprintManipulationWindow
                     findPaneOfTypeByID("tree", Text.class).setText(Component.literal(
                       structurePack.getName() + "/" + depth + "/" + blueprint.getFileName()).setStyle(Style.EMPTY.withBold(true)));
                     RenderingCache.getOrCreateBlueprintPreviewData("blueprint").setBlueprint(blueprint);
+                    adjustToGroundOffset();
                 }
                 updateLevels(leveled, categoryId + ":" + mapping.keySet().iterator().next(), false);
             }
@@ -1060,6 +1062,7 @@ public class WindowExtendedBuildTool extends AbstractBlueprintManipulationWindow
                 findPaneOfTypeByID("tree", Text.class).setText(Component.literal(
                   structurePack.getName() + "/" + depth + "/" + blueprint.getFileName()).setStyle(Style.EMPTY.withBold(true)));
                 RenderingCache.getOrCreateBlueprintPreviewData("blueprint").setBlueprint(blueprint);
+                adjustToGroundOffset();
             }
 
             if (list.size() == 1)
@@ -1085,6 +1088,7 @@ public class WindowExtendedBuildTool extends AbstractBlueprintManipulationWindow
                 final Blueprint blueprint = list.get(level);
                 findPaneOfTypeByID("tree", Text.class).setText(Component.literal(structurePack.getName() + "/" + depth + "/" + blueprint.getFileName()).setStyle(Style.EMPTY.withBold(true)));
                 RenderingCache.getOrCreateBlueprintPreviewData("blueprint").setBlueprint(blueprint);
+                adjustToGroundOffset();
                 return;
             }
             catch (final NumberFormatException exception)


### PR DESCRIPTION
# Changes proposed in this pull request:
- Makes groundlevel tags work again with the new build tool

Review please

I'm a little dubious about some of this -- there are several parts of the code which use `this.bluePrintId` (including the ground offset adjustment) and other parts that hardcode `"blueprint"` (such as the button-click handlers, as seen in this PR's diff).  This fix will _probably_ only work when these values are actually equal, unless I'm missing something.

While `bluePrintId` does seem to be equal to `"blueprint"` when using the build tool, it does look like it can sometimes be different, e.g. when using a supply camp/ship or the shape tool.  So there might still be a bug there, but I'm not sure which side is wrong.

Having said that, I did test out a supply camp with a groundlevel tag, and that was working ok, and of course the shape tool doesn't have tags.  So it does seem to work, even if it's a bit weird.