### PR TITLE
Fix placement of settings menu in shape tool

### DIFF
--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowExtendedBuildTool.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowExtendedBuildTool.java
@@ -165,7 +165,6 @@ public class WindowExtendedBuildTool extends AbstractBlueprintManipulationWindow
         placementOptionsList = findPaneOfTypeByID("placement", ScrollingList.class);
         alternativesList = findPaneOfTypeByID("alternatives", ScrollingList.class);
         levelsList = findPaneOfTypeByID("levels", ScrollingList.class);
-        settingsList.setPosition(5, 140);
 
         if (depth.isEmpty())
         {

--- a/src/main/resources/assets/structurize/gui/layoutmanipulation.xml
+++ b/src/main/resources/assets/structurize/gui/layoutmanipulation.xml
@@ -16,7 +16,7 @@
         <image id="rotation" size="16" pos="96 0"/>
     </view>
 
-    <list size="150 100" pos="5 150" id="settinglist" visible="false">
+    <list size="150 100" pos="5 140" id="settinglist" visible="false">
         <box size="100% 20" linewidth="0">
             <label size="110 17" pos="0 0" id="label"/>
             <button id="switch" source="structurize:textures/gui/builderhut/builder_button_very_small.png" size="29 15" pos="110 0" textColor="black" texthovercolor="gray"/>

--- a/src/main/resources/assets/structurize/gui/layoutmanipulation.xml
+++ b/src/main/resources/assets/structurize/gui/layoutmanipulation.xml
@@ -16,7 +16,7 @@
         <image id="rotation" size="16" pos="96 0"/>
     </view>
 
-    <list size="150 100" pos="5 50" id="settinglist" visible="false">
+    <list size="150 100" pos="5 150" id="settinglist" visible="false">
         <box size="100% 20" linewidth="0">
             <label size="110 17" pos="0 0" id="label"/>
             <button id="switch" source="structurize:textures/gui/builderhut/builder_button_very_small.png" size="29 15" pos="110 0" textColor="black" texthovercolor="gray"/>


### PR DESCRIPTION
# Changes proposed in this pull request:
- Fixes settings menu appearing incorrectly in shape tool gui
![img](https://user-images.githubusercontent.com/539951/186860363-2b4976b7-a798-4c17-bb0b-aff287bf696a.png)

Review please

~~Still not really sure why this was only happening in the shape tool and not the build tool, since they share code and xml.  But this doesn't break the build tool, and it seems like a more reasonable number anyway, so...~~