### PR TITLE
Fix crash if no packs

### DIFF
--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowExtendedBuildTool.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowExtendedBuildTool.java
@@ -149,6 +149,15 @@ public final class WindowExtendedBuildTool extends AbstractBlueprintManipulation
         }
 
         structurePack = StructurePacks.selectedPack;
+        if (structurePack == null)
+        {
+            if (StructurePacks.getPackMetas().isEmpty())
+            {
+                return;
+            }
+
+            structurePack = StructurePacks.selectedPack = StructurePacks.getPackMetas().iterator().next();
+        }
 
         registerButton(BUTTON_SWITCH_STYLE, this::switchPackClicked);
 
@@ -179,6 +188,19 @@ public final class WindowExtendedBuildTool extends AbstractBlueprintManipulation
             handleBlueprintCategory(up.contains(":") ? up : currentBlueprintCat, true);
         }
         updateRotationState();
+    }
+
+    @Override
+    public void onOpened()
+    {
+        if (structurePack == null)
+        {
+            Minecraft.getInstance().player.displayClientMessage(Component.translatable("structurize.pack.none"), false);
+            close();
+            return;
+        }
+
+        super.onOpened();
     }
 
     /**

--- a/src/main/resources/assets/structurize/lang/en_us.json
+++ b/src/main/resources/assets/structurize/lang/en_us.json
@@ -179,5 +179,6 @@
   "structurize.share.previews": "Shares Previews:",
   "structurize.display.shared": "See Previews from others:",
   "structurize.gui.manipulation.info": "Use the arrow buttons on the right to move the preview around or use the configured keys. You can exit and reposition via esc and then right click again to re-enter.",
-  "structurize.pack.missing.blueprint": "The Requested Blueprint does not exist on the Serverside in the same Pack. Either the Client Pack has been tampered with, or the Server Pack is outdated."
+  "structurize.pack.missing.blueprint": "The Requested Blueprint does not exist on the Serverside in the same Pack. Either the Client Pack has been tampered with, or the Server Pack is outdated.",
+  "structurize.pack.none": "No structure packs are installed. Scan something or install a mod that provides packs."
 }


### PR DESCRIPTION
# Changes proposed in this pull request:
- Fixes the direct cause of the crash in #537 (not having any packs, so not having a selected pack).

Review please

This does not address how it got into that state or the possibly related weirdness with the shape tool.