### PR TITLE
Local blueprints and style filters

### DIFF
--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowExtendedBuildTool.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowExtendedBuildTool.java
@@ -342,15 +342,9 @@ public final class WindowExtendedBuildTool extends AbstractBlueprintManipulation
                     }
                     else
                     {
-                        subCats.sort(Comparator.comparing((a) -> a.subPath));
                         for (final StructurePacks.Category subCat : subCats)
                         {
-                            String id = subCat.subPath.endsWith("/") ? subCat.subPath.substring(0, subCat.subPath.length() - 1) : subCat.subPath;
-                            if (id.startsWith("/"))
-                            {
-                                id = id.substring(1);
-                            }
-
+                            final String id = subCat.subPath;
                             if (subCat.isTerminal)
                             {
                                 blueprintsAtDepth.put(id, StructurePacks.getBlueprintsFuture(structurePack.getName(), id));
@@ -846,11 +840,7 @@ public final class WindowExtendedBuildTool extends AbstractBlueprintManipulation
         }
 
         final StructurePacks.Category subCat = (StructurePacks.Category) buttonData.data;
-        String id = subCat.subPath.endsWith("/") ? subCat.subPath.substring(0, subCat.subPath.length() - 1) : subCat.subPath;
-        if (id.startsWith("/"))
-        {
-            id = id.substring(1);
-        }
+        final String id = subCat.subPath;
 
         if (img == null)
         {


### PR DESCRIPTION
Depends on #551 (so will need to be rebased after that is merged, hence being a draft; or I guess this could be merged into that immediately prior, if that's easier and everyone's happy with this)

# Changes proposed in this pull request:
- If a stylepack folder contains both blueprints and subfolders, currently the blueprints are hidden.  This instead shows a "." subfolder in that case, which if selected will show just the blueprints.  (This is most useful for the player's scans, but can happen accidentally in another stylepack.)
    - e.g. if `infrastructure/foo.blueprint` and `infrastructure/roads/bar.blueprint` exist, then you will see the following tree:
        - Infrastructure
            - .
                - foo
            - Roads
                - bar
- Allows (but does not require, for backwards compatibility) the style pack selection window to accept a predicate to hide some of the style packs.
    - Test case for this (not yet pushed to mcol) was to make the Supplies window hide stylepacks that don't have the corresponding blueprint -- e.g. if a pack only has a camp and not a ship, then it will appear when using a camp and not when using a ship.

Review please
