### PR TITLE
Scan & command tweaks

### DIFF
--- a/src/main/java/com/ldtteam/structurize/commands/PasteCommand.java
+++ b/src/main/java/com/ldtteam/structurize/commands/PasteCommand.java
@@ -211,8 +211,8 @@ public class PasteCommand extends AbstractCommand
     {
         return newLiteral(commandName)
           .then(newArgument(POS, BlockPosArgument.blockPos())
-            .then(newArgument(PACK_NAME, StringArgumentType.word())
-              .then(newArgument(FILE_PATH, StringArgumentType.word())
+            .then(newArgument(PACK_NAME, StringArgumentType.string())
+              .then(newArgument(FILE_PATH, StringArgumentType.string())
                 .executes(PasteCommand::onExecute)
                 .then(newArgument(ROTATION, IntegerArgumentType.integer(0, 3))
                   .executes(PasteCommand::onExecuteWithRotation)

--- a/src/main/java/com/ldtteam/structurize/commands/PasteCommand.java
+++ b/src/main/java/com/ldtteam/structurize/commands/PasteCommand.java
@@ -54,6 +54,16 @@ public class PasteCommand extends AbstractCommand
     private static final String NO_PERMISSION_MESSAGE = "com.structurize.command.paste.no.perm";
 
     /**
+     * The invalid pack reply.
+     */
+    private static final String NO_PACK_MESSAGE = "com.structurize.command.paste.no.pack";
+
+    /**
+     * The invalid pack reply.
+     */
+    private static final String NO_BLUEPRINT_MESSAGE = "com.structurize.command.paste.no.blueprint";
+
+    /**
      * The player name command argument.
      */
     private static final String PLAYER_NAME = "player";
@@ -133,7 +143,19 @@ public class PasteCommand extends AbstractCommand
         }
         final String packName = packBuilder.toString();
 
-        final Blueprint blueprint = StructurePacks.getBlueprint(packName, path + ".blueprint");
+        if (!StructurePacks.hasPack(packName))
+        {
+            source.sendFailure(Component.translatable(NO_PACK_MESSAGE));
+            return 0;
+        }
+
+        final Blueprint blueprint = StructurePacks.getBlueprint(packName, path + ".blueprint", true);
+        if (blueprint == null)
+        {
+            source.sendFailure(Component.translatable(NO_BLUEPRINT_MESSAGE));
+            return 0;
+        }
+
         final BlockState anchor = blueprint.getBlockState(blueprint.getPrimaryBlockOffset());
         blueprint.rotateWithMirror(rotation, mirror, world);
 
@@ -161,7 +183,7 @@ public class PasteCommand extends AbstractCommand
         final StructurePlacer instantPlacer = new StructurePlacer(structure);
         Manager.addToQueue(new TickedWorldOperation(instantPlacer, player));
 
-        source.sendFailure(Component.translatable(PASTE_SUCCESS_MESSAGE));
+        source.sendSuccess(Component.translatable(PASTE_SUCCESS_MESSAGE), true);
         return 1;
     }
 

--- a/src/main/java/com/ldtteam/structurize/commands/PasteFolderCommand.java
+++ b/src/main/java/com/ldtteam/structurize/commands/PasteFolderCommand.java
@@ -273,8 +273,8 @@ public class PasteFolderCommand extends AbstractCommand
     {
         return newLiteral(commandName)
           .then(newArgument(POS, BlockPosArgument.blockPos())
-            .then(newArgument(PACK_NAME, StringArgumentType.word())
-              .then(newArgument(FILE_PATH, StringArgumentType.word())
+            .then(newArgument(PACK_NAME, StringArgumentType.string())
+              .then(newArgument(FILE_PATH, StringArgumentType.string())
                 .executes(PasteFolderCommand::onExecute)
                 .then(newArgument(ROTATION, IntegerArgumentType.integer(0, 3))
                   .executes(PasteFolderCommand::onExecuteWithRotation)

--- a/src/main/java/com/ldtteam/structurize/commands/PasteFolderCommand.java
+++ b/src/main/java/com/ldtteam/structurize/commands/PasteFolderCommand.java
@@ -62,6 +62,11 @@ public class PasteFolderCommand extends AbstractCommand
     private static final String NO_PERMISSION_MESSAGE = "com.structurize.command.paste.no.perm";
 
     /**
+     * The invalid pack reply.
+     */
+    private static final String NO_PACK_MESSAGE = "com.structurize.command.paste.no.pack";
+
+    /**
      * The player name command argument.
      */
     private static final String PLAYER_NAME = "player";
@@ -145,6 +150,12 @@ public class PasteFolderCommand extends AbstractCommand
             packBuilder.append(part);
         }
         final String packName = packBuilder.toString();
+
+        if (!StructurePacks.hasPack(packName))
+        {
+            source.sendFailure(Component.translatable(NO_PACK_MESSAGE));
+            return 0;
+        }
 
         ServerFutureProcessor.queueBlueprintList(new ServerFutureProcessor.BlueprintListProcessingData(StructurePacks.getBlueprintsFuture(packName, path), world, (list) -> {
 

--- a/src/main/resources/assets/structurize/gui/windowscantool.xml
+++ b/src/main/resources/assets/structurize/gui/windowscantool.xml
@@ -12,7 +12,7 @@
     <input id="pos2z" size="36 18" pos="320 5" maxlength="10"/>
 
     <label size="100 11" pos="72 35" color="white" label="$(com.ldtteam.structurize.gui.scantool.name)"/>
-    <input id="name" size="178 18" pos="130 30" maxlength="40"/>
+    <input id="name" size="178 18" pos="130 30" maxlength="80"/>
 
     <label size="30 11" pos="355 35" color="white" label="$(com.ldtteam.structurize.gui.scantool.slot)" textalign="MIDDLE_RIGHT"/>
     <input id="slot" size="18 18" pos="390 30" maxlength="2" enabled="false"/>

--- a/src/main/resources/assets/structurize/lang/en_us.json
+++ b/src/main/resources/assets/structurize/lang/en_us.json
@@ -59,6 +59,8 @@
   "com.structurize.command.scan.success": "Scan successfully saved",
 
   "com.structurize.command.paste.no.perm": "You don't have permission to paste via commands, use the Build Tool instead!",
+  "com.structurize.command.paste.no.pack": "The specified pack does not exist",
+  "com.structurize.command.paste.no.blueprint": "The specified blueprint does not exist",
   "com.structurize.command.paste.success": "Paste successfully triggered",
 
   "com.structurize.gui.buildtool.leave.tip": "Right-click the build tool on a solid block to adjust the build's position",


### PR DESCRIPTION
# Changes proposed in this pull request:
- Increases the length limit on the scan tool name -- now it can (and should) contain a path, so longer names are needed
- Allows the paste and pasteFolder commands to use quoted strings instead of dotted.words.
    - The dot conversions are still supported for backwards compatibility.  But perhaps could be removed for 1.20.  (Also why didn't they just use `String.replace`?)
- Gives better error responses for paste and pasteFolder in case the pack and/or blueprint specified don't actually exist.

Review please
