### PR TITLE
Don't pop neighbours on replace

### DIFF
--- a/src/main/java/com/ldtteam/structurize/util/BlockUtils.java
+++ b/src/main/java/com/ldtteam/structurize/util/BlockUtils.java
@@ -554,6 +554,10 @@ public final class BlockUtils
             }
 
             // place
+            if (blockNeedsRemoval(world, here))
+            {
+                world.removeBlock(here, false);
+            }
             world.setBlock(here, newState, Constants.UPDATE_FLAG);
             targetBlock.setPlacedBy(world, here, newState, fakePlayer, stackToPlace);
         }
@@ -574,6 +578,10 @@ public final class BlockUtils
             }
             else
             {
+                if (blockNeedsRemoval(world, here))
+                {
+                    world.removeBlock(here, false);
+                }
                 world.setBlock(here, fluid.defaultFluidState().createLegacyBlock(), Constants.UPDATE_FLAG);
                 bucket.checkExtraContent(null, world, stackToPlace, here);
             }
@@ -583,6 +591,14 @@ public final class BlockUtils
             throw new IllegalArgumentException(
                 MessageFormat.format("Cannot handle placing of {0} instead of {1}?!", itemStack.toString(), blockState.toString()));
         }
+    }
+
+    private static boolean blockNeedsRemoval(Level world, BlockPos pos)
+    {
+        final BlockState state = world.getBlockState(pos);
+        final Block block = state.getBlock();
+
+        return block instanceof DoorBlock || block instanceof DoublePlantBlock;
     }
 
     /**

--- a/src/main/java/com/ldtteam/structurize/util/BlockUtils.java
+++ b/src/main/java/com/ldtteam/structurize/util/BlockUtils.java
@@ -554,7 +554,6 @@ public final class BlockUtils
             }
 
             // place
-            world.removeBlock(here, false);
             world.setBlock(here, newState, Constants.UPDATE_FLAG);
             targetBlock.setPlacedBy(world, here, newState, fakePlayer, stackToPlace);
         }
@@ -575,7 +574,6 @@ public final class BlockUtils
             }
             else
             {
-                world.removeBlock(here, false);
                 world.setBlock(here, fluid.defaultFluidState().createLegacyBlock(), Constants.UPDATE_FLAG);
                 bucket.checkExtraContent(null, world, stackToPlace, here);
             }


### PR DESCRIPTION
# Changes proposed in this pull request:
- When using the scan tool's replace function, it no longer pops off neighbouring blocks (e.g. torches).

Review please (could backport)

One potential regression of this is that if you are replacing a block with itself then it might not reset the block entity any more -- though AFAIK it was not guaranteed to do so previously either.