### PR TITLE
Different method to avoid popping neighbours

### DIFF
--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowScan.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowScan.java
@@ -114,6 +114,11 @@ public class WindowScan extends AbstractWindowSkeleton
     private final ScrollingList entityList;
 
     /**
+     * True if using the replacement window
+     */
+    private boolean replacing;
+
+    /**
      * Constructor for when the player wants to scan something.
      * @param data the scan tool data
      */
@@ -206,6 +211,7 @@ public class WindowScan extends AbstractWindowSkeleton
         final List<ItemStorage> tempRes = new ArrayList<>(resources.values());
 
         new WindowReplaceBlock(tempRes.get(row).getItemStack(), new BlockPos(x1, y1, z1), new BlockPos(x2, y2, z2), this).open();
+        replacing = true;
     }
 
     @Override
@@ -243,6 +249,19 @@ public class WindowScan extends AbstractWindowSkeleton
         }
 
         super.onClosed();
+    }
+
+    @Override
+    public void onUpdate()
+    {
+        if (replacing)
+        {
+            // onOpened doesn't get called again when we're reopened from a child BO window
+            updateResources();
+            replacing = false;
+        }
+
+        super.onUpdate();
     }
 
     /**

--- a/src/main/java/com/ldtteam/structurize/util/BlockUtils.java
+++ b/src/main/java/com/ldtteam/structurize/util/BlockUtils.java
@@ -554,10 +554,7 @@ public final class BlockUtils
             }
 
             // place
-            if (blockNeedsRemoval(world, here))
-            {
-                world.removeBlock(here, false);
-            }
+            world.setBlock(here, Blocks.COBBLESTONE.defaultBlockState(), Block.UPDATE_NONE);
             world.setBlock(here, newState, Constants.UPDATE_FLAG);
             targetBlock.setPlacedBy(world, here, newState, fakePlayer, stackToPlace);
         }
@@ -578,10 +575,7 @@ public final class BlockUtils
             }
             else
             {
-                if (blockNeedsRemoval(world, here))
-                {
-                    world.removeBlock(here, false);
-                }
+                world.setBlock(here, Blocks.COBBLESTONE.defaultBlockState(), Block.UPDATE_NONE);
                 world.setBlock(here, fluid.defaultFluidState().createLegacyBlock(), Constants.UPDATE_FLAG);
                 bucket.checkExtraContent(null, world, stackToPlace, here);
             }
@@ -591,14 +585,6 @@ public final class BlockUtils
             throw new IllegalArgumentException(
                 MessageFormat.format("Cannot handle placing of {0} instead of {1}?!", itemStack.toString(), blockState.toString()));
         }
-    }
-
-    private static boolean blockNeedsRemoval(Level world, BlockPos pos)
-    {
-        final BlockState state = world.getBlockState(pos);
-        final Block block = state.getBlock();
-
-        return block instanceof DoorBlock || block instanceof DoublePlantBlock;
     }
 
     /**


### PR DESCRIPTION
# Changes proposed in this pull request:
- Different implementation for #560 since that caused issues with DO blocks not replacing
    - Note that DO blocks will still not replace properly with Structurize alone; needs placement handler currently implemented only in MineColonies too.
- Update the resource list after triggering replace
    - This works in SP; not tested in MP but very likely to not work there due to racing packets.  But no worse than existing behaviour.

Review please

The new implementation simply does an intermediate replace with a full-size block instead of the original replace-with-air; this avoids triggering the "not full block shape = pop" while still (mostly) forcing the BE to be removed when DO texture data is all that's changing.  Currently it just uses cobblestone for this; I considered using some other obviously-placeholder blocks but several candidates were either not full block shape or not removable in survival if something weird happened, so this seemed safest.