### PR TITLE
Remove simple type equality and calculate resource delta

### DIFF
--- a/src/main/java/com/ldtteam/structurize/placement/StructurePlacer.java
+++ b/src/main/java/com/ldtteam/structurize/placement/StructurePlacer.java
@@ -205,7 +205,6 @@ public class StructurePlacer
       CompoundTag tileEntityData)
     {
         final BlockState worldState = world.getBlockState(worldPos);
-        boolean sameBlockInWorld = worldState.getBlock() == localState.getBlock();
 
         if (!(worldState.getBlock() instanceof AirBlock))
         {
@@ -323,15 +322,9 @@ public class StructurePlacer
             {
                 final List<ItemStack> requiredItems = new ArrayList<>();
 
-                if (!sameBlockInWorld && !this.handler.isCreative())
+                if (!this.handler.isCreative())
                 {
-                    for (final ItemStack stack : placementHandler.getRequiredItems(world, worldPos, localState, tileEntityData, false))
-                    {
-                        if (!stack.isEmpty() && !this.handler.isStackFree(stack))
-                        {
-                            requiredItems.add(stack);
-                        }
-                    }
+                    requiredItems.addAll(placementHandler.getRequiredItemsVsWorld(world, worldPos, localState, tileEntityData, false));
 
                     if (!this.handler.hasRequiredItems(requiredItems))
                     {
@@ -341,7 +334,7 @@ public class StructurePlacer
 
                 if (!(worldState.getBlock() instanceof AirBlock))
                 {
-                    if (!sameBlockInWorld
+                    if (localState.getBlock() != worldState.getBlock()
                           && worldState.getMaterial() != Material.AIR
                           && !(worldState.getBlock() instanceof DoublePlantBlock && worldState.getValue(DoublePlantBlock.HALF).equals(DoubleBlockHalf.UPPER)))
                     {
@@ -365,7 +358,7 @@ public class StructurePlacer
                     return new BlockPlacementResult(worldPos, BlockPlacementResult.Result.SUCCESS);
                 }
 
-                if (!this.handler.isCreative() && !sameBlockInWorld)
+                if (!this.handler.isCreative())
                 {
                     for (final ItemStack tempStack : requiredItems)
                     {
@@ -398,13 +391,6 @@ public class StructurePlacer
       BlockState localState,
       CompoundTag tileEntityData)
     {
-        final BlockState worldState = world.getBlockState(worldPos);
-        boolean sameBlockInWorld = false;
-        if (worldState.getBlock() == localState.getBlock())
-        {
-            sameBlockInWorld = true;
-        }
-
         final List<ItemStack> requiredItems = new ArrayList<>();
         for (final CompoundTag compound : iterator.getBluePrintPositionInfo(localPos).getEntities())
         {
@@ -471,16 +457,16 @@ public class StructurePlacer
         {
             if (placementHandler.canHandle(world, worldPos, localState))
             {
-                if (!sameBlockInWorld)
+                final List<ItemStack> missingItems = placementHandler.getRequiredItemsVsWorld(world, worldPos, localState, tileEntityData, false);
+
+                for (final ItemStack stack : missingItems)
                 {
-                    for (final ItemStack stack : placementHandler.getRequiredItems(world, worldPos, localState, tileEntityData, false))
+                    if (!stack.isEmpty() && !this.handler.isStackFree(stack))
                     {
-                        if (!stack.isEmpty() && !this.handler.isStackFree(stack))
-                        {
-                            requiredItems.add(stack);
-                        }
+                        requiredItems.add(stack);
                     }
                 }
+
                 return new BlockPlacementResult(worldPos, BlockPlacementResult.Result.MISSING_ITEMS, requiredItems);
             }
         }

--- a/src/main/java/com/ldtteam/structurize/placement/StructurePlacer.java
+++ b/src/main/java/com/ldtteam/structurize/placement/StructurePlacer.java
@@ -324,7 +324,13 @@ public class StructurePlacer
 
                 if (!this.handler.isCreative())
                 {
-                    requiredItems.addAll(placementHandler.getRequiredItemsVsWorld(world, worldPos, localState, tileEntityData, false));
+                    for (final ItemStack stack : placementHandler.getRequiredItemsVsWorld(world, worldPos, localState, tileEntityData, false))
+                    {
+                        if (!stack.isEmpty() && !this.handler.isStackFree(stack))
+                        {
+                            requiredItems.add(stack);
+                        }
+                    }
 
                     if (!this.handler.hasRequiredItems(requiredItems))
                     {

--- a/src/main/java/com/ldtteam/structurize/placement/handlers/placement/PlacementHandlers.java
+++ b/src/main/java/com/ldtteam/structurize/placement/handlers/placement/PlacementHandlers.java
@@ -54,7 +54,6 @@ public final class PlacementHandlers
         handlers.add(new DoublePlantPlacementHandler());
         handlers.add(new SpecialBlockPlacementAttemptHandler());
         handlers.add(new FlowerPotPlacementHandler());
-        handlers.add(new StairBlockPlacementHandler());
         handlers.add(new HopperClientLagPlacementHandler());
         handlers.add(new ContainerPlacementHandler());
         handlers.add(new FallingBlockPlacementHandler());
@@ -649,42 +648,6 @@ public final class PlacementHandlers
         }
     }
 
-    public static class StairBlockPlacementHandler implements IPlacementHandler
-    {
-        @Override
-        public boolean canHandle(final Level world, final BlockPos pos, final BlockState blockState)
-        {
-            return blockState.getBlock() instanceof StairBlock
-                     && !(blockState.getBlock() instanceof EntityBlock)
-                     && world.getBlockState(pos).getBlock() instanceof StairBlock
-                     && world.getBlockState(pos).getValue(StairBlock.FACING) == blockState.getValue(StairBlock.FACING)
-                     && blockState.getBlock() == world.getBlockState(pos).getBlock();
-        }
-
-        @Override
-        public ActionProcessingResult handle(
-          final Level world,
-          final BlockPos pos,
-          final BlockState blockState,
-          @Nullable final CompoundTag tileEntityData,
-          final boolean complete,
-          final BlockPos centerPos)
-        {
-            return ActionProcessingResult.PASS;
-        }
-
-        @Override
-        public List<ItemStack> getRequiredItems(
-          final Level world,
-          final BlockPos pos,
-          final BlockState blockState,
-          @Nullable final CompoundTag tileEntityData,
-          final boolean complete)
-        {
-            return new ArrayList<>();
-        }
-    }
-
     public static class GeneralBlockPlacementHandler implements IPlacementHandler
     {
         @Override
@@ -705,12 +668,6 @@ public final class PlacementHandlers
         {
             if (world.getBlockState(pos).equals(blockState))
             {
-                world.removeBlock(pos, false);
-                world.setBlock(pos, blockState, UPDATE_FLAG);
-                if (tileEntityData != null)
-                {
-                    handleTileEntityPlacement(tileEntityData, world, pos, settings);
-                }
                 return ActionProcessingResult.PASS;
             }
 


### PR DESCRIPTION
Closes #580

# Changes proposed in this pull request:
- Removes simple block type equality check and early exit for resource requirements.
- Instead calculates a proper delta between the resources for the existing block vs. the resources for the new block (when they're the same type).
- Removes a stair placement handler whose only purpose in life appears to be to ignore blockstate changes to stairs for no readily apparent reason.  (Though oddly not ignoring changes to only one of the three properties of stairs.)
    - This appears to be the reason why stairs weren't flipped upside down during upgrade/paste unless they also changed block type.

Review please

Posting as a draft since this probably needs more testing, though I've tested it with MineColonies and with likely problematic blocks like racks and chests in addition to DO blocks.  Suggestions welcome for additional cases, or you can try it out yourself from the PR build.

Given a blueprint that has DO blocks that vary only by materials, this will now consider these to be "different" and will show them as requirements in the resource list in both the upgrade preview and the builder's request lists.

Most blocks that are the same blockstate but different NBT will be left untouched via [`BlockUtil.areBlockStatesEqual`](https://github.com/ldtteam/Structurize/blob/1871e0c222113d0467be335ad6afad5dc9c6b451/src/main/java/com/ldtteam/structurize/util/BlockUtils.java#L373) -- which deliberately has an exception for DO blocks, which made me assume that the "free upgrade" behaviour was indeed unintended.

Most blocks that have different blockstates will be replaced, unless a placement handler says otherwise.  This is the potentially most risky part of the patch.  Notably, racks have such a handler.

One interesting consequence of these changes is that if the blueprint contains a chest or rack with contents, and the chest/rack already exists with different contents, then the resource requirements will calculate the blueprint contents not present in the world (but not the reverse) and will make the builder ask for them, but then will not actually put them in the chest (because it's too risky to update the contents).  But this doesn't seem entirely like a bad thing, and in most cases the blueprints have empty chests/racks this won't behave any different.