### PR TITLE
Fix/rotate mirror

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -50,7 +50,7 @@ dataGeneratorsVersion=1.19.3-0.1.54-ALPHA
 
 requiredCurseDependencies=domum-ornamentum;blockui
 
-useDefaultTestSystem=false
+useDefaultTestSystem=true
 runtimeSourceSets=api;test;main
 librarySourceSets=api;test;main;datagen;
 projectHasApi=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,22 +10,22 @@ javaVersion=17
 useJavaToolChains=true
 
 #The currently running forge.
-forgeVersion=46.0.12
+forgeVersion=47.1.3
 #The minimal needed forge, as marked in metadata and curseforge.
-forgeMinVersion=46.0.12
-fmlRange=[46,)
-forgeRange=[46.0.12,)
+forgeMinVersion=47.1.0
+fmlRange=[47,)
+forgeRange=[47.1.0,)
 
 #The version for forge (dependency)
-exactMinecraftVersion=1.20
-minecraftRange=[1.20, 1.21)
+exactMinecraftVersion=1.20.1
+minecraftRange=[1.20.1, 1.21)
 #The main version on curseforge
-minecraftVersion=1.20
+minecraftVersion=1.20.1
 #Comma seperated list of mc versions, which are marked as compatible on curseforge
-additionalMinecraftVersions=1.20.1
+additionalMinecraftVersions=
 
 mappingsChannel=official
-mappingsVersion=1.20
+mappingsVersion=1.20.1
 
 blockUiVersion=1.20-0.0.83-ALPHA
 blockUiRange=[1.20-0.0.83-ALPHA,)

--- a/src/main/java/com/ldtteam/structurize/blockentities/BlockEntityTagSubstitution.java
+++ b/src/main/java/com/ldtteam/structurize/blockentities/BlockEntityTagSubstitution.java
@@ -2,6 +2,7 @@ package com.ldtteam.structurize.blockentities;
 
 import com.ldtteam.structurize.blockentities.interfaces.IBlueprintDataProviderBE;
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
+import com.ldtteam.structurize.util.RotationMirror;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
@@ -342,17 +343,8 @@ public class BlockEntityTagSubstitution extends BlockEntity implements IBlueprin
             return blueprint;
         }
 
-        /**
-         * Rotates and mirrors the replacement data, in response to a blueprint containing this replacement block
-         * being rotated or mirrored.
-         *
-         * @param pos the world location for the replacement block
-         * @param localRotation the relative rotation
-         * @param localMirror the relative mirror
-         * @param world the (actual) world
-         * @return the new replacement data
-         */
         @NotNull
+        @Deprecated(since="1.20", forRemoval=true)
         public BlockEntityTagSubstitution.ReplacementBlock rotateWithMirror(@NotNull final BlockPos pos,
                                                                             @NotNull final Rotation localRotation,
                                                                             @NotNull final Mirror localMirror,
@@ -360,6 +352,25 @@ public class BlockEntityTagSubstitution extends BlockEntity implements IBlueprin
         {
             final Blueprint blueprint = createBlueprint();
             blueprint.rotateWithMirror(localRotation, localMirror, world);
+
+            final BlockState newBlockState = blueprint.getBlockState(BlockPos.ZERO);
+            final CompoundTag newBlockData = blueprint.getTileEntityData(pos, BlockPos.ZERO);
+            return new ReplacementBlock(newBlockState, newBlockData, this.getItemStack());
+        }
+
+        /**
+         * Rotates and mirrors the replacement data, in response to a blueprint containing this replacement block
+         * being rotated or mirrored.
+         *
+         * @param pos the world location for the replacement block
+         * @param rotationMirror the relative rotation/mirror
+         * @param level the (actual) world
+         * @return the new replacement data
+         */
+        public ReplacementBlock rotateWithMirror(final BlockPos pos, final RotationMirror rotationMirror, final Level level)
+        {
+            final Blueprint blueprint = createBlueprint();
+            blueprint.setRotationMirrorRelative(rotationMirror, level);
 
             final BlockState newBlockState = blueprint.getBlockState(BlockPos.ZERO);
             final CompoundTag newBlockData = blueprint.getTileEntityData(pos, BlockPos.ZERO);

--- a/src/main/java/com/ldtteam/structurize/blueprints/v1/Blueprint.java
+++ b/src/main/java/com/ldtteam/structurize/blueprints/v1/Blueprint.java
@@ -11,7 +11,7 @@ import com.ldtteam.structurize.blockentities.interfaces.IBlueprintDataProviderBE
 import com.ldtteam.structurize.util.BlockInfo;
 import com.ldtteam.structurize.util.BlockUtils;
 import com.ldtteam.structurize.util.BlueprintPositionInfo;
-
+import com.ldtteam.structurize.util.RotationMirror;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -25,7 +25,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
 
@@ -124,19 +123,9 @@ public class Blueprint
     private BlockPos cachePrimaryOffset = null;
 
     /**
-     * Source of rendering.
+     * The rotation and mirror setting of the blueprint.
      */
-    private BlockPos renderSource = BlockPos.ZERO;
-
-    /**
-     * The rotation setting of the blueprint.
-     */
-    private Rotation rotation = Rotation.NONE;
-
-    /**
-     * The mirror setting of the blueprint.
-     */
-    private Mirror mirror = Mirror.NONE;
+    private RotationMirror rotationMirror = RotationMirror.NONE;
 
     /**
      * Constructor of a new Blueprint.
@@ -616,35 +605,34 @@ public class Blueprint
         cacheEntitiesMap = null;
     }
 
-    /**
-     * Rotate the structure depending on the direction it's facing.
-     *
-     * @param localRotation times to rotateWithMirror.
-     * @param localMirror   the mirror.
-     * @param world    the world.
-     */
-    public void rotateWithMirror(final Rotation localRotation, final Mirror localMirror, final Level world)
+    public void setRotationMirror(final RotationMirror rotationMirror, final Level level)
     {
-        final Rotation rotDifference = Rotation.values()[Math.floorMod(localRotation.ordinal() - this.rotation.ordinal(), Rotation.values().length)];
-        final Mirror mirDifference;
-        if (this.mirror == localMirror)
-        {
-            mirDifference = Mirror.NONE;
-        }
-        else if (this.mirror == Mirror.NONE)
-        {
-            mirDifference = localMirror;
-        }
-        else
-        {
-            mirDifference = this.mirror;
-        }
+        setRotationMirrorRelative(this.rotationMirror.calcDifferenceTowards(rotationMirror), level);
+    }
 
+    /**
+     * 
+     * @param transformBy what to apply 
+     * @param level world for entity construction
+     */
+    public void setRotationMirrorRelative(final RotationMirror transformBy, final Level level)
+    {
         final BlockPos primaryOffset = getPrimaryBlockOffset();
-        final BlockPos resultSize = transformedSize(new BlockPos(sizeX, sizeY, sizeZ), rotDifference);
-        final short newSizeX = (short) resultSize.getX();
-        final short newSizeY = (short) resultSize.getY();
-        final short newSizeZ = (short) resultSize.getZ();
+        final short newSizeX, newSizeZ, newSizeY = sizeY;
+
+        switch (transformBy.rotation())
+        {
+            case COUNTERCLOCKWISE_90:
+            case CLOCKWISE_90:
+                newSizeX = sizeZ;
+                newSizeZ = sizeX;
+                break;
+
+            default:
+                newSizeX = sizeX;
+                newSizeZ = sizeZ;
+                break;
+        }
 
         final short[][][] newStructure = new short[newSizeY][newSizeZ][newSizeX];
         final CompoundTag[] newEntities = new CompoundTag[entities.length];
@@ -653,10 +641,10 @@ public class Blueprint
         final List<BlockState> palette = new ArrayList<>();
         for (int i = 0; i < this.palette.size(); i++)
         {
-            palette.add(i, this.palette.get(i).mirror(mirDifference).rotate(rotDifference));
+            palette.add(i, this.palette.get(i).mirror(transformBy.mirror()).rotate(transformBy.rotation()));
         }
 
-        final BlockPos extremes = transformedBlockPos(sizeX, sizeY, sizeZ, mirDifference, rotDifference);
+        final BlockPos extremes = transformBy.applyToPos(new BlockPos(sizeX, sizeY, sizeZ));
         int minX = extremes.getX() < 0 ? -extremes.getX() - 1 : 0;
         int minY = extremes.getY() < 0 ? -extremes.getY() - 1 : 0;
         int minZ = extremes.getZ() < 0 ? -extremes.getZ() - 1 : 0;
@@ -669,13 +657,13 @@ public class Blueprint
             {
                 for (short z = 0; z < this.sizeZ; z++)
                 {
-                    final BlockPos tempPos = transformedBlockPos(x, y, z, mirDifference, rotDifference).offset(minX, minY, minZ);
                     final short value = structure[y][z][x];
                     final BlockState state = palette.get(value & 0xFFFF);
                     if (state.getBlock() == Blocks.STRUCTURE_VOID)
                     {
                         continue;
                     }
+                    final BlockPos tempPos = transformBy.applyToPos(new BlockPos(x, y, z)).offset(minX, minY, minZ);
                     newStructure[tempPos.getY()][tempPos.getZ()][tempPos.getX()] = value;
 
                     final CompoundTag compound = tileEntities[y][z][x];
@@ -694,7 +682,7 @@ public class Blueprint
                         {
                             BlockEntityTagSubstitution.ReplacementBlock replacement =
                                     new BlockEntityTagSubstitution.ReplacementBlock(compound);
-                            replacement = replacement.rotateWithMirror(tempPos, rotDifference, mirDifference, world);
+                            replacement = replacement.rotateWithMirror(tempPos, transformBy, level);
                             replacement.write(compound);
                         }
 
@@ -708,18 +696,14 @@ public class Blueprint
 
                             for (Map.Entry<BlockPos, List<String>> entry : tagPosMap.entrySet())
                             {
-                                newTagPosMap.put(transformedBlockPos(entry.getKey(), mirDifference, rotDifference), entry.getValue());
+                                newTagPosMap.put(transformBy.applyToPos(entry.getKey()), entry.getValue());
                             }
 
                             IBlueprintDataProviderBE.writeMapToCompound(dataCompound, newTagPosMap);
 
                             // Rotate corners
-                            BlockPos corner1 = BlockPosUtil.readFromNBT(dataCompound, TAG_CORNER_ONE);
-                            BlockPos corner2 = BlockPosUtil.readFromNBT(dataCompound, TAG_CORNER_TWO);
-                            corner1 = transformedBlockPos(corner1, mirDifference, rotDifference);
-                            corner2 = transformedBlockPos(corner2, mirDifference, rotDifference);
-                            BlockPosUtil.writeToNBT(dataCompound, TAG_CORNER_ONE, corner1);
-                            BlockPosUtil.writeToNBT(dataCompound, TAG_CORNER_TWO, corner2);
+                            BlockPosUtil.writeToNBT(dataCompound, TAG_CORNER_ONE, transformBy.applyToPos(BlockPosUtil.readFromNBT(dataCompound, TAG_CORNER_ONE)));
+                            BlockPosUtil.writeToNBT(dataCompound, TAG_CORNER_TWO, transformBy.applyToPos(BlockPosUtil.readFromNBT(dataCompound, TAG_CORNER_TWO)));
                         }
                     }
                     newTileEntities[tempPos.getY()][tempPos.getZ()][tempPos.getX()] = compound;
@@ -732,13 +716,11 @@ public class Blueprint
             final CompoundTag entitiesCompound = entities[i];
             if (entitiesCompound != null)
             {
-                newEntities[i] = transformEntityInfoWithSettings(entitiesCompound, world, new BlockPos(minX, minY, minZ), rotDifference, mirDifference);
+                newEntities[i] = transformEntityInfoWithSettings(entitiesCompound, level, new BlockPos(minX, minY, minZ), transformBy);
             }
         }
 
-        BlockPos newOffsetPos = StructureTemplate.transform(primaryOffset, mirDifference, rotDifference, new BlockPos(0, 0, 0));
-
-        setCachePrimaryOffset(newOffsetPos.offset(minX, minY, minZ));
+        setCachePrimaryOffset(transformBy.applyToPos(primaryOffset).offset(minX, minY, minZ));
 
         sizeX = newSizeX;
         sizeY = newSizeY;
@@ -747,84 +729,23 @@ public class Blueprint
         this.structure = newStructure;
         this.entities = newEntities;
         this.tileEntities = newTileEntities;
+        this.rotationMirror = this.rotationMirror.add(transformBy);
 
         cacheReset(false);
-
-        this.rotation = localRotation;
-        this.mirror = localMirror;
     }
 
     /**
-     * Calculate the transformed size from a blockpos.
+     * Rotate the structure depending on the direction it's facing.
      *
-     * @param pos      the pos to transform
-     * @param rotation the rotation to apply.
-     * @return the resulting size.
+     * @param localRotation times to rotateWithMirror.
+     * @param localMirror   the mirror.
+     * @param world    the world.
+     * @deprecated replaced by {@link #setRotationMirrorRelative(RotationMirror, Level)}
      */
-    public static BlockPos transformedSize(final BlockPos pos, final Rotation rotation)
+    @Deprecated(since="1.20", forRemoval=true)
+    public void rotateWithMirror(final Rotation localRotation, final Mirror localMirror, final Level world)
     {
-        switch (rotation)
-        {
-            case COUNTERCLOCKWISE_90:
-            case CLOCKWISE_90:
-                return new BlockPos(pos.getZ(), pos.getY(), pos.getX());
-
-            default:
-                return pos;
-        }
-    }
-
-    
-    public static BlockPos transformedBlockPos(final BlockPos pos, final Mirror mirror, final Rotation rotation)
-    {
-        return transformedBlockPos(pos.getX(), pos.getY(), pos.getZ(), mirror, rotation);
-    }
-
-    /**
-     * Transforms a blockpos with mirror and rotation.
-     *
-     * @param xIn      the x input.
-     * @param y        the y input.
-     * @param zIn      the z input.
-     * @param mirror   the mirror.
-     * @param rotation the rotation.
-     * @return the resulting position.
-     */
-    public static BlockPos transformedBlockPos(final int xIn, final int y, final int zIn, final Mirror mirror, final Rotation rotation)
-    {
-        int x = xIn;
-        int z = zIn;
-
-        boolean flag = true;
-
-        switch (mirror)
-        {
-            case LEFT_RIGHT:
-                z = -zIn;
-                break;
-
-            case FRONT_BACK:
-                x = -xIn;
-                break;
-
-            default:
-                flag = false;
-        }
-
-        switch (rotation)
-        {
-            case COUNTERCLOCKWISE_90:
-                return new BlockPos(z, y, -x);
-
-            case CLOCKWISE_90:
-                return new BlockPos(-z, y, x);
-
-            case CLOCKWISE_180:
-                return new BlockPos(-x, y, -z);
-
-            default:
-                return flag ? new BlockPos(x, y, z) : new BlockPos(xIn, y, zIn);
-        }
+        setRotationMirrorRelative(RotationMirror.of(localRotation, localMirror), world);
     }
 
     /**
@@ -833,15 +754,13 @@ public class Blueprint
      * @param entityInfo the entity nbt.
      * @param world      the world.
      * @param pos        the position.
-     * @param rotation   the wanted rotation.
-     * @param mirror     the mirror.
+     * @param rotationMirror   the wanted rotation/mirror.
      * @return the updated nbt.
      */
-    private CompoundTag transformEntityInfoWithSettings(final CompoundTag entityInfo,
+    private static CompoundTag transformEntityInfoWithSettings(final CompoundTag entityInfo,
         final Level world,
         final BlockPos pos,
-        final Rotation rotation,
-        final Mirror mirror)
+        final RotationMirror rotationMirror)
     {
         final Optional<EntityType<?>> type = EntityType.by(entityInfo);
         if (type.isPresent())
@@ -854,13 +773,12 @@ public class Blueprint
                 {
                     finalEntity.deserializeNBT(entityInfo);
 
-                    final Vec3 entityVec = Blueprint
-                        .transformedVector3d(rotation,
-                            mirror,
+                    final Vec3 entityVec = rotationMirror
+                        .applyToPos(
                             finalEntity instanceof HangingEntity hang ? Vec3.atCenterOf(hang.getPos()) : finalEntity.position())
                         .add(Vec3.atLowerCornerOf(pos));
-                    finalEntity.setYRot(finalEntity.mirror(mirror));
-                    finalEntity.setYRot(finalEntity.rotate(rotation));
+                    finalEntity.setYRot(finalEntity.mirror(rotationMirror.mirror()));
+                    finalEntity.setYRot(finalEntity.rotate(rotationMirror.rotation()));
                     finalEntity.moveTo(entityVec.x, entityVec.y, entityVec.z, finalEntity.getYRot(), finalEntity.getXRot());
 
                     return finalEntity.serializeNBT();
@@ -873,50 +791,6 @@ public class Blueprint
             }
         }
         return null;
-    }
-
-    /**
-     * Transform a Vector3d with rotation and mirror.
-     *
-     * @param rotation the rotation.
-     * @param mirror   the mirror.
-     * @param vec      the vec to transform.
-     * @return the result.
-     */
-    private static Vec3 transformedVector3d(final Rotation rotation, final Mirror mirror, final Vec3 vec)
-    {
-        double xCoord = vec.x;
-        double zCoord = vec.z;
-        boolean flag = true;
-
-        switch (mirror)
-        {
-            case LEFT_RIGHT:
-                zCoord = 1.0D - zCoord;
-                break;
-
-            case FRONT_BACK:
-                xCoord = 1.0D - xCoord;
-                break;
-
-            default:
-                flag = false;
-        }
-
-        switch (rotation)
-        {
-            case COUNTERCLOCKWISE_90:
-                return new Vec3(zCoord, vec.y, 1.0D - xCoord);
-
-            case CLOCKWISE_90:
-                return new Vec3(1.0D - zCoord, vec.y, xCoord);
-
-            case CLOCKWISE_180:
-                return new Vec3(1.0D - xCoord, vec.y, 1.0D - zCoord);
-
-            default:
-                return flag ? new Vec3(xCoord, vec.y, zCoord) : vec;
-        }
     }
 
     private int getVolume()
@@ -947,11 +821,10 @@ public class Blueprint
         {
             return true;
         }
-        if (!(obj instanceof Blueprint))
+        if (!(obj instanceof final Blueprint other))
         {
             return false;
         }
-        final Blueprint other = (Blueprint) obj;
         return Objects.equals(name, other.name)
                  && Objects.equals(fileName, other.fileName)
                  && Objects.equals(filePath, other.filePath)
@@ -960,17 +833,6 @@ public class Blueprint
                  && entities.length == other.entities.length
                  && tileEntities.length == other.tileEntities.length
                  && getVolume() == other.getVolume();
-    }
-
-    /**
-     * Set the render source of the blueprint.
-     * This will be included in the hash to differentiate.
-     * This is supposed to be used for static blueprints that are not moved around only.
-     * @param pos the source position.
-     */
-    public void setRenderSource(final BlockPos pos)
-    {
-        this.renderSource = pos;
     }
 
     /**
@@ -994,7 +856,7 @@ public class Blueprint
      * @param pos        the pos to check.
      * @return true if so.
      */
-    private boolean isAtPos(final CompoundTag entityData, final BlockPos pos)
+    private static boolean isAtPos(final CompoundTag entityData, final BlockPos pos)
     {
         final ListTag list = entityData.getList(ENTITY_POS, 6);
         final int x = (int) list.getDouble(0);
@@ -1026,21 +888,22 @@ public class Blueprint
         return this::getRawBlockState;
     }
 
-    /**
-     * Get the mirror value
-     * @return
-     */
-    public Mirror getMirror()
+    @Override
+    public String toString()
     {
-        return mirror;
-    }
-
-    /**
-     * Get the rotation value
-     * @return
-     */
-    public Rotation getRotation()
-    {
-        return rotation;
+        return "Blueprint [size=[" + sizeX +
+            ", " +
+            sizeY +
+            ", " +
+            sizeZ +
+            "], fileName=" +
+            fileName +
+            ", filePath=" +
+            filePath +
+            ", packName=" +
+            packName +
+            ", name=" +
+            name +
+            "]";
     }
 }

--- a/src/main/java/com/ldtteam/structurize/blueprints/v1/Blueprint.java
+++ b/src/main/java/com/ldtteam/structurize/blueprints/v1/Blueprint.java
@@ -37,6 +37,8 @@ import static com.ldtteam.structurize.blockentities.interfaces.IBlueprintDataPro
 
 /**
  * The blueprint class which contains the file format for the schematics.
+ * 
+ * WARNING: hashcode/equals does NOT take rotation/mirror into account
  */
 public class Blueprint
 {
@@ -605,15 +607,25 @@ public class Blueprint
         cacheEntitiesMap = null;
     }
 
+    /**
+     * Rotates and mirrors entire exactly to given param
+     * 
+     * @param rotationMirror exact rot/mir
+     * @param level world for entity construction
+     * @see #setRotationMirrorRelative(RotationMirror, Level) setRotationMirrorRelative for relative addition
+     */
     public void setRotationMirror(final RotationMirror rotationMirror, final Level level)
     {
         setRotationMirrorRelative(this.rotationMirror.calcDifferenceTowards(rotationMirror), level);
     }
 
     /**
+     * Rotates and mirrors entire content additively, formula:
+     * current state + transformBy = target state
      * 
-     * @param transformBy what to apply 
+     * @param transformBy rot/mir to add
      * @param level world for entity construction
+     * @see #setRotationMirror(RotationMirror, Level) setRotationMirror for exact setter
      */
     public void setRotationMirrorRelative(final RotationMirror transformBy, final Level level)
     {
@@ -740,7 +752,7 @@ public class Blueprint
      * @param localRotation times to rotateWithMirror.
      * @param localMirror   the mirror.
      * @param world    the world.
-     * @deprecated replaced by {@link #setRotationMirrorRelative(RotationMirror, Level)}
+     * @deprecated replaced by {@link #setRotationMirrorRelative(RotationMirror, Level)} or use exact setter {@link #setRotationMirror(RotationMirror, Level)}
      */
     @Deprecated(since="1.20", forRemoval=true)
     public void rotateWithMirror(final Rotation localRotation, final Mirror localMirror, final Level world)
@@ -811,6 +823,7 @@ public class Blueprint
         result = prime * result + entities.length;
         result = prime * result + tileEntities.length;
         result = prime * result + getVolume();
+        // rot/mir intentionally not incluced
         return result;
     }
 
@@ -833,6 +846,7 @@ public class Blueprint
                  && entities.length == other.entities.length
                  && tileEntities.length == other.tileEntities.length
                  && getVolume() == other.getVolume();
+        // rot/mir intentionally not incluced
     }
 
     /**

--- a/src/main/java/com/ldtteam/structurize/blueprints/v1/Blueprint.java
+++ b/src/main/java/com/ldtteam/structurize/blueprints/v1/Blueprint.java
@@ -916,6 +916,8 @@ public class Blueprint
             packName +
             ", name=" +
             name +
+            ", rotMir=" +
+            rotationMirror +
             "]";
     }
 }

--- a/src/main/java/com/ldtteam/structurize/blueprints/v1/Blueprint.java
+++ b/src/main/java/com/ldtteam/structurize/blueprints/v1/Blueprint.java
@@ -836,6 +836,18 @@ public class Blueprint
     }
 
     /**
+     * Set the render source of the blueprint.
+     * This will be included in the hash to differentiate.
+     * This is supposed to be used for static blueprints that are not moved around only.
+     * @param pos the source position.
+     * @deprecated ask Ray what to use :)
+     */
+    @Deprecated(since = "1.20", forRemoval = true)
+    public void setRenderSource(final BlockPos pos)
+    {
+    }
+
+    /**
      * Get blueprint info at position.
      * 
      * @param pos             the position

--- a/src/main/java/com/ldtteam/structurize/client/BlueprintHandler.java
+++ b/src/main/java/com/ldtteam/structurize/client/BlueprintHandler.java
@@ -129,6 +129,9 @@ public final class BlueprintHandler
         Minecraft.getInstance().getProfiler().pop();
     }
 
+    /**
+     * Hacky record to add rot/mir to blueprint hashcode (which is rot/mir independent)
+     */
     public record RenderingCacheKey(RotationMirror rotationMirror, Blueprint blueprint)
     {
     }

--- a/src/main/java/com/ldtteam/structurize/client/BlueprintHandler.java
+++ b/src/main/java/com/ldtteam/structurize/client/BlueprintHandler.java
@@ -65,10 +65,11 @@ public final class BlueprintHandler
     }
 
     /**
-     * Draw a blueprint with a rotation, mirror and offset.
+     * Draw a blueprint at given pos.
      *
      * @param previewData the blueprint and context to draw.
-     * @param pos       its position.
+     * @param pos         position to render at
+     * @param ctx         rendering event
      */
     public void draw(final BlueprintPreviewData previewData, final BlockPos pos, final RenderLevelStageEvent ctx)
     {
@@ -101,10 +102,11 @@ public final class BlueprintHandler
     }
 
     /**
-     * Render a blueprint at a list of points.
+     * Draw a blueprint at list of given pos.
      *
-     * @param points       the points to render it at.
-     * @param partialTicks the partial ticks.
+     * @param previewData the blueprint and context to draw.
+     * @param points      list of positions to render at
+     * @param ctx         rendering event
      */
     public void drawAtListOfPositions(final BlueprintPreviewData previewData,
         final List<BlockPos> points,

--- a/src/main/java/com/ldtteam/structurize/client/BlueprintHandler.java
+++ b/src/main/java/com/ldtteam/structurize/client/BlueprintHandler.java
@@ -1,19 +1,18 @@
 package com.ldtteam.structurize.client;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.ldtteam.structurize.api.util.Log;
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
 import com.ldtteam.structurize.storage.rendering.types.BlueprintPreviewData;
-import it.unimi.dsi.fastutil.ints.Int2LongArrayMap;
-import it.unimi.dsi.fastutil.ints.Int2LongMap;
-import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
+import com.ldtteam.structurize.util.RotationMirror;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.block.Mirror;
-import net.minecraft.world.level.block.Rotation;
 import net.minecraftforge.client.event.RenderLevelStageEvent;
 
-import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * The Blueprint render handler on the client side.
@@ -24,11 +23,26 @@ public final class BlueprintHandler
      * A static instance on the client.
      */
     private static final BlueprintHandler ourInstance = new BlueprintHandler();
-    private static final int CACHE_SIZE = 30;
-    private static final long CACHE_EVICT_TIME = 45_000L;
+    /**
+     * How long are cache entries valid
+     */
+    public static final int CACHE_EXPIRE_SECONDS = 45;
+    /**
+     * How often should cache cleanup happen
+     */
+    public static final int CACHE_EXPIRE_CHECK_SECONDS = CACHE_EXPIRE_SECONDS / 3;
 
-    private final Int2ObjectArrayMap<BlueprintRenderer> rendererCache = new Int2ObjectArrayMap<>(CACHE_SIZE);
-    private final Int2LongArrayMap evictTimeCache = new Int2LongArrayMap(CACHE_SIZE);
+    private final LoadingCache<RenderingCacheKey, BlueprintRenderer> rendererCache = CacheBuilder.newBuilder()
+        .expireAfterAccess(CACHE_EXPIRE_SECONDS, TimeUnit.SECONDS)
+        .<RenderingCacheKey, BlueprintRenderer>removalListener(entry -> entry.getValue().close())
+        .build(new CacheLoader<>()
+        {
+            @Override
+            public BlueprintRenderer load(final RenderingCacheKey key)
+            {
+                return BlueprintRenderer.buildRendererForBlueprint(key.blueprint());
+            }
+        });
 
     /**
      * Private constructor to hide public one.
@@ -64,33 +78,10 @@ public final class BlueprintHandler
             return;
         }
         Minecraft.getInstance().getProfiler().push("struct_render_cache");
-
-        final int blueprintHash = getRenderHashFor(previewData.getBlueprint());
-        final BlueprintRenderer rendererRef = rendererCache.get(blueprintHash);
-        final BlueprintRenderer renderer = rendererRef == null ? BlueprintRenderer.buildRendererForBlueprint(previewData.getBlueprint()) : rendererRef;
-
-        if (rendererRef == null)
-        {
-            rendererCache.put(blueprintHash, renderer);
-        }
-
-        renderer.draw(previewData, pos, ctx);
-        evictTimeCache.put(blueprintHash, System.currentTimeMillis());
+        
+        rendererCache.getUnchecked(previewData.getRenderKey()).draw(previewData, pos, ctx);
 
         Minecraft.getInstance().getProfiler().pop();
-    }
-
-    /**
-     * Calcualtes a custom render hash for blueprints, including rotation and mirroring
-     * // TODO: No longer needed once rendering is able to rotate/mirror the displayed schematic
-     * @param blueprint
-     * @return
-     */
-    private static int getRenderHashFor(final Blueprint blueprint)
-    {
-        int result = blueprint.hashCode();
-        result = 31 * result + blueprint.getRotation().hashCode();
-        return 31 * result + blueprint.getMirror().hashCode();
     }
 
     /**
@@ -98,18 +89,7 @@ public final class BlueprintHandler
      */
     public void cleanCache()
     {
-        final long now = System.currentTimeMillis();
-        final Iterator<Int2LongMap.Entry> iter = evictTimeCache.int2LongEntrySet().iterator();
-
-        while (iter.hasNext())
-        {
-            final Int2LongMap.Entry entry = iter.next();
-            if (entry.getLongValue() + CACHE_EVICT_TIME < now)
-            {
-                rendererCache.remove(entry.getIntKey()).close();
-                iter.remove();
-            }
-        }
+        rendererCache.cleanUp();
     }
 
     /**
@@ -117,9 +97,7 @@ public final class BlueprintHandler
      */
     public void clearCache()
     {
-        evictTimeCache.clear();
-        rendererCache.values().forEach(BlueprintRenderer::close);
-        rendererCache.clear();
+        rendererCache.invalidateAll();
     }
 
     /**
@@ -139,22 +117,17 @@ public final class BlueprintHandler
 
         Minecraft.getInstance().getProfiler().push("struct_render_multi");
 
-        final int blueprintHash = previewData.getBlueprint().hashCode();
-        final BlueprintRenderer rendererRef = rendererCache.get(blueprintHash);
-        final BlueprintRenderer renderer = rendererRef == null ? BlueprintRenderer.buildRendererForBlueprint(previewData.getBlueprint()) : rendererRef;
-
-        if (rendererRef == null)
-        {
-            rendererCache.put(blueprintHash, renderer);
-        }
+        final BlueprintRenderer renderer = rendererCache.getUnchecked(previewData.getRenderKey());
 
         for (final BlockPos coord : points)
         {
             renderer.draw(previewData, coord, ctx);
         }
 
-        evictTimeCache.put(blueprintHash, System.currentTimeMillis());
-
         Minecraft.getInstance().getProfiler().pop();
+    }
+
+    public record RenderingCacheKey(RotationMirror rotationMirror, Blueprint blueprint)
+    {
     }
 }

--- a/src/main/java/com/ldtteam/structurize/client/BlueprintRenderer.java
+++ b/src/main/java/com/ldtteam/structurize/client/BlueprintRenderer.java
@@ -55,11 +55,11 @@ import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.client.event.RenderLevelStageEvent;
 import net.minecraftforge.client.model.data.ModelData;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.joml.Matrix4f;
 import org.joml.Vector3f;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -77,7 +77,7 @@ import static com.ldtteam.structurize.api.util.constant.Constants.RENDER_PLACEHO
  */
 public class BlueprintRenderer implements AutoCloseable
 {
-    private static final Logger LOGGER = LogManager.getLogger();
+    private static final Logger LOGGER = LoggerFactory.getLogger(BlueprintRenderer.class);
     private static final Supplier<Map<RenderType, VertexBuffer>> blockVertexBuffersFactory = () -> RenderType.chunkBufferLayers()
         .stream()
         .collect(Collectors.toMap((type) -> type, (type) -> new VertexBuffer(VertexBuffer.Usage.STATIC)));
@@ -242,6 +242,7 @@ public class BlueprintRenderer implements AutoCloseable
                 vertexBuffer.upload(newBuffer);
             }
         }
+        newBuffers.clearAll();
         VertexBuffer.unbind();
     }
 

--- a/src/main/java/com/ldtteam/structurize/client/BlueprintRenderer.java
+++ b/src/main/java/com/ldtteam/structurize/client/BlueprintRenderer.java
@@ -111,14 +111,11 @@ public class BlueprintRenderer implements AutoCloseable
      * Updates blueprint reference if it has same hash.
      *
      * @param previewData blueprint and context from active structure
+     * @deprecated no longer needed
      */
+    @Deprecated(since = "1.20", forRemoval = true)
     public void updateBlueprint(final BlueprintPreviewData previewData)
     {
-        if (blockAccess.getBlueprint() != previewData.getBlueprint() && blockAccess.getBlueprint().hashCode() == previewData.getBlueprint().hashCode())
-        {
-            blockAccess.setBlueprint(previewData.getBlueprint());
-            previewData.scheduleRefresh();
-        }
     }
 
     private void init(final BlockPos anchorPos)
@@ -275,7 +272,7 @@ public class BlueprintRenderer implements AutoCloseable
         }
 
         // init
-        if (previewData.shouldRefresh() || vertexBuffers == null)
+        if (vertexBuffers == null)
         {
             init(anchorPos);
         }

--- a/src/main/java/com/ldtteam/structurize/client/gui/AbstractBlueprintManipulationWindow.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/AbstractBlueprintManipulationWindow.java
@@ -447,24 +447,15 @@ public abstract class AbstractBlueprintManipulationWindow extends AbstractWindow
      */
     protected void updateRotationState()
     {
-        findPaneOfTypeByID(BUTTON_MIRROR, ButtonImage.class).setImage(new ResourceLocation(MOD_ID, String.format(RES_STRING, BUTTON_MIRROR + (RenderingCache.getOrCreateBlueprintPreviewData(bluePrintId).getMirror().equals(Mirror.NONE) ? "" : GREEN_POS))), false);
+        findPaneOfTypeByID(BUTTON_MIRROR, ButtonImage.class).setImage(new ResourceLocation(MOD_ID, String.format(RES_STRING, BUTTON_MIRROR + (RenderingCache.getOrCreateBlueprintPreviewData(bluePrintId).getRotationMirror().mirror().equals(Mirror.NONE) ? "" : GREEN_POS))), false);
 
-        String rotation;
-        switch (RenderingCache.getOrCreateBlueprintPreviewData(bluePrintId).getRotation())
+        final String rotation = switch (RenderingCache.getOrCreateBlueprintPreviewData(bluePrintId).getRotationMirror().rotation())
         {
-            case CLOCKWISE_90:
-                rotation = "right_green";
-                break;
-            case CLOCKWISE_180:
-                rotation = "down_green";
-                break;
-            case COUNTERCLOCKWISE_90:
-                rotation = "left_green";
-                break;
-            default:
-                rotation = "up_green";
-                break;
-        }
+            case CLOCKWISE_90 -> "right_green";
+            case CLOCKWISE_180 -> "down_green";
+            case COUNTERCLOCKWISE_90 -> "left_green";
+            case NONE -> "up_green";
+        };
         findPaneOfTypeByID(IMAGE_ROTATION, Image.class).setImage(new ResourceLocation(MOD_ID, String.format(RES_STRING, rotation)), false);
     }
 

--- a/src/main/java/com/ldtteam/structurize/client/gui/AbstractBlueprintManipulationWindow.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/AbstractBlueprintManipulationWindow.java
@@ -353,7 +353,7 @@ public abstract class AbstractBlueprintManipulationWindow extends AbstractWindow
                 buttonImage.setHandler((button) -> {
                     settings.get(index).setValue(!settings.get(index).getValue());
                     Network.getNetwork().sendToServer(new SyncSettingsToServer());
-                    RenderingCache.getOrCreateBlueprintPreviewData(bluePrintId).scheduleRefresh();
+                    RenderingCache.getOrCreateBlueprintPreviewData(bluePrintId).syncChangesToServer();
                 });
             }
         });

--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowExtendedBuildTool.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowExtendedBuildTool.java
@@ -256,8 +256,8 @@ public final class WindowExtendedBuildTool extends AbstractBlueprintManipulation
                             structurePack.getName(),
                             structurePack.getSubPath(previewData.getBlueprint().getFilePath().resolve(previewData.getBlueprint().getFileName() + ".blueprint")),
                             previewData.getPos(),
-                            previewData.getRotation(),
-                            previewData.getMirror()));
+                            previewData.getRotationMirror().rotation(),
+                            previewData.getRotationMirror().mirror()));
             if (type == BuildToolPlacementMessage.HandlerType.Survival)
             {
                 cancelClicked();

--- a/src/main/java/com/ldtteam/structurize/commands/PasteCommand.java
+++ b/src/main/java/com/ldtteam/structurize/commands/PasteCommand.java
@@ -8,6 +8,7 @@ import com.ldtteam.structurize.placement.structure.CreativeStructureHandler;
 import com.ldtteam.structurize.placement.structure.IStructureHandler;
 import com.ldtteam.structurize.storage.StructurePacks;
 import com.ldtteam.structurize.util.PlacementSettings;
+import com.ldtteam.structurize.util.RotationMirror;
 import com.ldtteam.structurize.util.TickedWorldOperation;
 import com.mojang.authlib.GameProfile;
 import com.mojang.brigadier.arguments.BoolArgumentType;
@@ -154,7 +155,7 @@ public class PasteCommand extends AbstractCommand
         }
 
         final BlockState anchor = blueprint.getBlockState(blueprint.getPrimaryBlockOffset());
-        blueprint.rotateWithMirror(rotation, mirror, world);
+        blueprint.setRotationMirror(RotationMirror.of(rotation, mirror), world);
 
         final IStructureHandler structure;
         if (anchor.getBlock() instanceof ISpecialCreativeHandlerAnchorBlock)

--- a/src/main/java/com/ldtteam/structurize/commands/PasteFolderCommand.java
+++ b/src/main/java/com/ldtteam/structurize/commands/PasteFolderCommand.java
@@ -10,6 +10,7 @@ import com.ldtteam.structurize.placement.structure.IStructureHandler;
 import com.ldtteam.structurize.storage.ServerFutureProcessor;
 import com.ldtteam.structurize.storage.StructurePacks;
 import com.ldtteam.structurize.util.PlacementSettings;
+import com.ldtteam.structurize.util.RotationMirror;
 import com.ldtteam.structurize.util.TickedWorldOperation;
 import com.mojang.brigadier.arguments.BoolArgumentType;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
@@ -188,7 +189,7 @@ public class PasteFolderCommand extends AbstractCommand
                 for (final Blueprint blueprint : perTypeList)
                 {
                     final BlockState anchor = blueprint.getBlockState(blueprint.getPrimaryBlockOffset());
-                    blueprint.rotateWithMirror(rotation, mirror, world);
+                    blueprint.setRotationMirror(RotationMirror.of(rotation, mirror), world);
                     final BlockPos placementPos = pos.offset(xOffset, 0, zOffset).offset(blueprint.getPrimaryBlockOffset());
 
                     final IStructureHandler structure;

--- a/src/main/java/com/ldtteam/structurize/event/ClientEventSubscriber.java
+++ b/src/main/java/com/ldtteam/structurize/event/ClientEventSubscriber.java
@@ -160,7 +160,7 @@ public class ClientEventSubscriber
         final Minecraft mc = Minecraft.getInstance();
         mc.getProfiler().push("structurize");
 
-        if (mc.level != null && mc.level.getGameTime() % (Constants.TICKS_SECOND * 5) == 0)
+        if (mc.level != null && mc.level.getGameTime() % (Constants.TICKS_SECOND * BlueprintHandler.CACHE_EXPIRE_CHECK_SECONDS) == 0)
         {
             mc.getProfiler().push("blueprint_manager_tick");
             BlueprintHandler.getInstance().cleanCache();

--- a/src/main/java/com/ldtteam/structurize/placement/StructurePlacementUtils.java
+++ b/src/main/java/com/ldtteam/structurize/placement/StructurePlacementUtils.java
@@ -6,6 +6,7 @@ import com.ldtteam.structurize.placement.structure.IStructureHandler;
 import com.ldtteam.structurize.api.util.Log;
 import com.ldtteam.structurize.management.Manager;
 import com.ldtteam.structurize.util.PlacementSettings;
+import com.ldtteam.structurize.util.RotationMirror;
 import com.ldtteam.structurize.util.TickedWorldOperation;
 import net.minecraft.world.level.block.AirBlock;
 import net.minecraft.server.level.ServerPlayer;
@@ -31,7 +32,7 @@ public class StructurePlacementUtils
     public static void unloadStructure(final Level world, final BlockPos startPos, final Blueprint blueprint, final Rotation rotation, final Mirror mirror)
     {
         final IStructureHandler structure = new CreativeStructureHandler(world, startPos, blueprint, new PlacementSettings(mirror, rotation), false);
-        structure.getBluePrint().rotateWithMirror(rotation, mirror, world);
+        structure.getBluePrint().setRotationMirror(RotationMirror.of(rotation, mirror), world);
 
         final StructurePlacer placer = new StructurePlacer(structure);
         placer.executeStructureStep(world, null, new BlockPos(0, 0, 0), StructurePlacer.Operation.BLOCK_REMOVAL,
@@ -64,7 +65,7 @@ public class StructurePlacementUtils
             {
                 structure.fancyPlacement();
             }
-            structure.getBluePrint().rotateWithMirror(rotation, mirror, worldObj);
+            structure.getBluePrint().setRotationMirror(RotationMirror.of(rotation, mirror), worldObj);
 
             final StructurePlacer instantPlacer = new StructurePlacer(structure);
             Manager.addToQueue(new TickedWorldOperation(instantPlacer, player));

--- a/src/main/java/com/ldtteam/structurize/placement/structure/AbstractStructureHandler.java
+++ b/src/main/java/com/ldtteam/structurize/placement/structure/AbstractStructureHandler.java
@@ -4,6 +4,7 @@ import com.ldtteam.structurize.blockentities.interfaces.IBlueprintDataProviderBE
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
 import com.ldtteam.structurize.storage.StructurePacks;
 import com.ldtteam.structurize.util.PlacementSettings;
+import com.ldtteam.structurize.util.RotationMirror;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
@@ -120,7 +121,7 @@ public abstract class AbstractStructureHandler implements IStructureHandler
             try
             {
                 blueprint = blueprintFuture.get();
-                blueprint.rotateWithMirror(settings.getRotation(), settings.getMirror() == Mirror.NONE ? Mirror.NONE : Mirror.FRONT_BACK, world);
+                blueprint.setRotationMirror(settings.getRotationMirror(), world);
             }
             catch (InterruptedException | ExecutionException e)
             {

--- a/src/main/java/com/ldtteam/structurize/storage/BlueprintPlacementHandling.java
+++ b/src/main/java/com/ldtteam/structurize/storage/BlueprintPlacementHandling.java
@@ -17,9 +17,9 @@ import com.ldtteam.structurize.placement.structure.CreativeStructureHandler;
 import com.ldtteam.structurize.placement.structure.IStructureHandler;
 import com.ldtteam.structurize.util.IOPool;
 import com.ldtteam.structurize.util.PlacementSettings;
+import com.ldtteam.structurize.util.RotationMirror;
 import com.ldtteam.structurize.util.TickedWorldOperation;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.forgespi.language.IModInfo;
@@ -87,7 +87,7 @@ public class BlueprintPlacementHandling
 
         Utils.playSuccessSound(message.player);
         final BlockState anchor = blueprint.getBlockState(blueprint.getPrimaryBlockOffset());
-        blueprint.rotateWithMirror(message.rotation, message.mirror == Mirror.NONE ? Mirror.NONE : Mirror.FRONT_BACK, message.world);
+        blueprint.setRotationMirror(RotationMirror.of(message.rotation, message.mirror), message.world);
 
         final IStructureHandler structure;
         if (anchor.getBlock() instanceof ISpecialCreativeHandlerAnchorBlock)

--- a/src/main/java/com/ldtteam/structurize/storage/rendering/types/BlueprintPreviewData.java
+++ b/src/main/java/com/ldtteam/structurize/storage/rendering/types/BlueprintPreviewData.java
@@ -44,11 +44,6 @@ public class BlueprintPreviewData
     private int groundOffset  = 0;
 
     /**
-     * If data has to be refreshed.
-     */
-    private boolean shouldRefresh = false;
-
-    /**
      * Holds the blueprint to be rendered that is still loading.
      */
     @Nullable
@@ -215,7 +210,7 @@ public class BlueprintPreviewData
     /**
      * Sync the changes to the server.
      */
-    private void syncChangesToServer()
+    public void syncChangesToServer()
     {
         if (BlueprintRenderSettings.instance.renderSettings.get(SHARE_PREVIEWS) && (blueprint == null || blueprint.getName() != null))
         {
@@ -238,20 +233,21 @@ public class BlueprintPreviewData
     /**
      * Check if the blueprint rendered should refresh the cache.
      * @return true if so.
+     * @deprecated no longer needed
      */
+    @Deprecated(since = "1.20", forRemoval = true)
     public boolean shouldRefresh()
     {
-        final boolean ret = shouldRefresh;
-        shouldRefresh = false;
-        return ret;
+        return false;
     }
 
     /**
      * Tell the structurize renderer to refresh the cache.
+     * @deprecated switch to {@link #syncChangesToServer()}
      */
+    @Deprecated(since = "1.20", forRemoval = true)
     public void scheduleRefresh()
     {
-        shouldRefresh = true;
         syncChangesToServer();
     }
 
@@ -338,7 +334,7 @@ public class BlueprintPreviewData
         blueprint.setRotationMirror(rotationMirror, Minecraft.getInstance().level);
         renderKey = new RenderingCacheKey(rotationMirror, blueprint);
 
-        scheduleRefresh();
+        syncChangesToServer();
     }
 
     public RenderingCacheKey getRenderKey()

--- a/src/main/java/com/ldtteam/structurize/storage/rendering/types/BlueprintPreviewData.java
+++ b/src/main/java/com/ldtteam/structurize/storage/rendering/types/BlueprintPreviewData.java
@@ -225,13 +225,13 @@ public class BlueprintPreviewData
 
     /**
      * Move this preview by an offset.
-     * @param by the offset to move it by.
+     * @param offset the offset to move it by.
      */
-    public void move(final BlockPos by)
+    public void move(final BlockPos offset)
     {
         if (this.pos != null)
         {
-            setPos(pos.offset(by));
+            setPos(pos.offset(offset));
         }
     }
 

--- a/src/main/java/com/ldtteam/structurize/storage/rendering/types/BlueprintPreviewData.java
+++ b/src/main/java/com/ldtteam/structurize/storage/rendering/types/BlueprintPreviewData.java
@@ -11,6 +11,7 @@ import com.ldtteam.structurize.util.RotationMirror;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -257,6 +258,7 @@ public class BlueprintPreviewData
     /**
      * Get the placement settings for this instance.
      * @return the placement settings with mirror and rotation.
+     * @deprecated see {@link #getRotationMirror()}
      */
     @Deprecated(since = "1.20", forRemoval = true)
     public PlacementSettings getPlacementSettings()
@@ -271,6 +273,28 @@ public class BlueprintPreviewData
     public boolean isEmpty()
     {
         return blueprintFuture == null && blueprint == null;
+    }
+
+    /**
+     * Get the rotation of the preview.
+     * @return the rotation.
+     * @deprecated see {@link #getRotationMirror()}
+     */
+    @Deprecated(since = "1.20", forRemoval = true)
+    public Rotation getRotation()
+    {
+        return rotationMirror.rotation();
+    }
+
+    /**
+     * Get the mirror of the preview.
+     * @return the mirror.
+     * @deprecated see {@link #getRotationMirror()}
+     */
+    @Deprecated(since = "1.20", forRemoval = true)
+    public Mirror getMirror()
+    {
+        return rotationMirror.mirror();
     }
 
     /**

--- a/src/main/java/com/ldtteam/structurize/storage/rendering/types/BlueprintPreviewData.java
+++ b/src/main/java/com/ldtteam/structurize/storage/rendering/types/BlueprintPreviewData.java
@@ -15,7 +15,6 @@ import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.concurrent.ExecutionException;
@@ -31,7 +30,6 @@ public class BlueprintPreviewData
     /**
      * The rotation/mirror of the preview.
      */
-    @NotNull
     private RotationMirror rotationMirror = RotationMirror.NONE;
 
     /**
@@ -53,11 +51,13 @@ public class BlueprintPreviewData
     /**
      * Holds the blueprint to be rendered that is still loading.
      */
+    @Nullable
     private Future<Blueprint> blueprintFuture;
 
     /**
      * Holds the blueprint to be rendered.
      */
+    @Nullable
     private Blueprint blueprint;
 
     /**

--- a/src/main/java/com/ldtteam/structurize/storage/rendering/types/BlueprintPreviewData.java
+++ b/src/main/java/com/ldtteam/structurize/storage/rendering/types/BlueprintPreviewData.java
@@ -2,14 +2,15 @@ package com.ldtteam.structurize.storage.rendering.types;
 
 import com.ldtteam.structurize.Network;
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
+import com.ldtteam.structurize.client.BlueprintHandler.RenderingCacheKey;
 import com.ldtteam.structurize.config.BlueprintRenderSettings;
 import com.ldtteam.structurize.network.messages.SyncPreviewCacheToServer;
 import com.ldtteam.structurize.storage.StructurePacks;
 import com.ldtteam.structurize.util.PlacementSettings;
+import com.ldtteam.structurize.util.RotationMirror;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -27,16 +28,10 @@ import static com.ldtteam.structurize.api.util.constant.Constants.SHARE_PREVIEWS
 public class BlueprintPreviewData
 {
     /**
-     * The rotation of the preview.
+     * The rotation/mirror of the preview.
      */
     @NotNull
-    private Rotation rotation = Rotation.NONE;
-
-    /**
-     * The mirror of the preview.
-     */
-    @NotNull
-    private Mirror mirror = Mirror.NONE;
+    private RotationMirror rotationMirror = RotationMirror.NONE;
 
     /**
      * The position of the preview.
@@ -71,6 +66,11 @@ public class BlueprintPreviewData
     private String packName = "";
 
     /**
+     * Used for blueprint renderer
+     */
+    private RenderingCacheKey renderKey;
+
+    /**
      * Default constructor to create a new setup.
      */
     public BlueprintPreviewData()
@@ -95,8 +95,7 @@ public class BlueprintPreviewData
         {
             blueprintFuture = null;
         }
-        rotation = Rotation.values()[byteBuf.readInt()];
-        mirror = Mirror.values()[byteBuf.readInt()];
+        rotationMirror = RotationMirror.values()[byteBuf.readByte()];
     }
 
     /**
@@ -117,8 +116,7 @@ public class BlueprintPreviewData
             byteBuf.writeUtf(StructurePacks.selectedPack.getName());
             byteBuf.writeUtf(StructurePacks.selectedPack.getSubPath(blueprint.getFilePath().resolve(blueprint.getFileName() + ".blueprint")));
         }
-        byteBuf.writeInt(rotation.ordinal());
-        byteBuf.writeInt(mirror.ordinal());
+        byteBuf.writeByte(rotationMirror.ordinal());
     }
 
     /**
@@ -160,9 +158,8 @@ public class BlueprintPreviewData
             {
                 if (blueprintFuture.get() != null)
                 {
-                    this.blueprint = blueprintFuture.get();
+                    setBlueprint(blueprintFuture.get());
                     this.blueprintFuture = null;
-                    this.blueprint.rotateWithMirror(this.rotation, this.mirror, Minecraft.getInstance().level);
                 }
             }
             catch (InterruptedException | ExecutionException e)
@@ -182,15 +179,14 @@ public class BlueprintPreviewData
     public void setBlueprint(final Blueprint blueprint)
     {
         this.blueprintFuture = null;
-        if (blueprint != null && !blueprint.equals(this.blueprint))
+        if (blueprint == null)
         {
-            this.blueprint = blueprint;
-            this.blueprint.rotateWithMirror(this.rotation, this.mirror, Minecraft.getInstance().level);
-            scheduleRefresh();
+            this.blueprint = null;
         }
-        else
+        else if (!blueprint.equals(this.blueprint))
         {
             this.blueprint = blueprint;
+            applyRotationMirrorAndSync();
         }
     }
 
@@ -200,22 +196,8 @@ public class BlueprintPreviewData
     @OnlyIn(Dist.CLIENT)
     public void mirror()
     {
-        if (blueprint == null)
-        {
-            return;
-        }
-
-        if (mirror == Mirror.NONE)
-        {
-            mirror = this.rotation.ordinal() % 2 == 0 ? Mirror.FRONT_BACK : Mirror.LEFT_RIGHT;
-        }
-        else
-        {
-            mirror = Mirror.NONE;
-        }
-        this.blueprint.rotateWithMirror(this.rotation, this.mirror, Minecraft.getInstance().level);
-
-        syncChangesToServer();
+        this.rotationMirror = this.rotationMirror.mirrorate();
+        applyRotationMirrorAndSync();
     }
 
     /**
@@ -225,12 +207,8 @@ public class BlueprintPreviewData
     @OnlyIn(Dist.CLIENT)
     public void rotate(final Rotation rotation)
     {
-        this.rotation = this.rotation.getRotated(rotation);
-        if (blueprint != null)
-        {
-            blueprint.rotateWithMirror(this.rotation, this.mirror, Minecraft.getInstance().level);
-        }
-        syncChangesToServer();
+        this.rotationMirror = this.rotationMirror.rotate(rotation);
+        applyRotationMirrorAndSync();
     }
 
     /**
@@ -246,14 +224,13 @@ public class BlueprintPreviewData
 
     /**
      * Move this preview by an offset.
-     * @param pos the offset to move it by.
+     * @param by the offset to move it by.
      */
-    public void move(final BlockPos pos)
+    public void move(final BlockPos by)
     {
         if (this.pos != null)
         {
-            this.pos = this.pos.offset(pos);
-            syncChangesToServer();
+            setPos(pos.offset(by));
         }
     }
 
@@ -281,9 +258,10 @@ public class BlueprintPreviewData
      * Get the placement settings for this instance.
      * @return the placement settings with mirror and rotation.
      */
+    @Deprecated(since = "1.20", forRemoval = true)
     public PlacementSettings getPlacementSettings()
     {
-        return new PlacementSettings(mirror, rotation);
+        return new PlacementSettings(rotationMirror.mirror(), rotationMirror.rotation());
     }
 
     /**
@@ -296,21 +274,12 @@ public class BlueprintPreviewData
     }
 
     /**
-     * Get the rotation of the preview.
-     * @return the rotation.
+     * Get the placement settings for this instance.
+     * @return the placement settings with mirror and rotation.
      */
-    public Rotation getRotation()
+    public RotationMirror getRotationMirror()
     {
-        return rotation;
-    }
-
-    /**
-     * Get the mirror of the preview.
-     * @return the mirror.
-     */
-    public Mirror getMirror()
-    {
-        return mirror;
+        return rotationMirror;
     }
 
     /**
@@ -329,5 +298,31 @@ public class BlueprintPreviewData
     public void setPos(final BlockPos pos)
     {
         this.pos = pos;
+        if (pos != null)
+        {
+            syncChangesToServer();
+        }
+    }
+
+    private void applyRotationMirrorAndSync()
+    {
+        if (blueprint == null)
+        {
+            return;
+        }
+
+        blueprint.setRotationMirror(rotationMirror, Minecraft.getInstance().level);
+        renderKey = new RenderingCacheKey(rotationMirror, blueprint);
+
+        scheduleRefresh();
+    }
+
+    public RenderingCacheKey getRenderKey()
+    {
+        if (blueprintFuture != null)
+        {
+            getBlueprint();
+        }
+        return renderKey;
     }
 }

--- a/src/main/java/com/ldtteam/structurize/util/PlacementSettings.java
+++ b/src/main/java/com/ldtteam/structurize/util/PlacementSettings.java
@@ -61,4 +61,9 @@ public class PlacementSettings
     {
         this.rotation = rotation;
     }
+
+    public RotationMirror getRotationMirror()
+    {
+        return RotationMirror.of(rotation, mirror);
+    }
 }

--- a/src/main/java/com/ldtteam/structurize/util/PlacementSettings.java
+++ b/src/main/java/com/ldtteam/structurize/util/PlacementSettings.java
@@ -5,7 +5,9 @@ import net.minecraft.world.level.block.Rotation;
 
 /**
  * Placement settings for the blueprints.
+ * @deprecated use {@link RotationMirror}
  */
+@Deprecated(since = "1.20", forRemoval = true)
 public class PlacementSettings
 {
     /**

--- a/src/main/java/com/ldtteam/structurize/util/RotationMirror.java
+++ b/src/main/java/com/ldtteam/structurize/util/RotationMirror.java
@@ -94,9 +94,9 @@ public enum RotationMirror
         return mirror;
     }
 
-    public RotationMirror rotate(final Rotation by)
+    public RotationMirror rotate(final Rotation offset)
     {
-        return switch (by)
+        return switch (offset)
         {
             case CLOCKWISE_90 -> rotateCW90;
             case CLOCKWISE_180 -> rotateCW180;

--- a/src/main/java/com/ldtteam/structurize/util/RotationMirror.java
+++ b/src/main/java/com/ldtteam/structurize/util/RotationMirror.java
@@ -1,7 +1,6 @@
 package com.ldtteam.structurize.util;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.gametest.framework.StructureUtils;
 import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
@@ -20,6 +19,9 @@ public enum RotationMirror
     MIR_R90(Rotation.CLOCKWISE_90, Mirror.FRONT_BACK),
     MIR_R180(Rotation.CLOCKWISE_180, Mirror.FRONT_BACK),
     MIR_R270(Rotation.COUNTERCLOCKWISE_90, Mirror.FRONT_BACK);
+
+    public static final RotationMirror[] MIRRORED = {MIR_NONE, MIR_R90, MIR_R180, MIR_R270};
+    public static final RotationMirror[] NOT_MIRRORED = {NONE, R90, R180, R270};
 
     static
     {
@@ -51,22 +53,22 @@ public enum RotationMirror
         MIR_R270.rotateCCW90 = MIR_R180;
 
         NONE.mirrorFB = MIR_NONE;
-        R90.mirrorFB = MIR_R90;
+        R90.mirrorFB = MIR_R270;
         R180.mirrorFB = MIR_R180;
-        R270.mirrorFB = MIR_R270;
+        R270.mirrorFB = MIR_R90;
         MIR_NONE.mirrorFB = NONE;
-        MIR_R90.mirrorFB = R90;
+        MIR_R90.mirrorFB = R270;
         MIR_R180.mirrorFB = R180;
-        MIR_R270.mirrorFB = R270;
+        MIR_R270.mirrorFB = R90;
 
         NONE.mirrorLR = MIR_R180;
-        R90.mirrorLR = MIR_R270;
+        R90.mirrorLR = MIR_R90;
         R180.mirrorLR = MIR_NONE;
-        R270.mirrorLR = MIR_R90;
+        R270.mirrorLR = MIR_R270;
         MIR_NONE.mirrorLR = R180;
-        MIR_R90.mirrorLR = R270;
+        MIR_R90.mirrorLR = R90;
         MIR_R180.mirrorLR = NONE;
-        MIR_R270.mirrorLR = R90;
+        MIR_R270.mirrorLR = R270;
     }
 
     private final Rotation rotation;
@@ -172,9 +174,14 @@ public enum RotationMirror
      */
     public RotationMirror calcDifferenceTowards(final RotationMirror end)
     {
-        final int rotDiff =
-            StructureUtils.getRotationStepsForRotation(end.rotation) - StructureUtils.getRotationStepsForRotation(this.rotation);
-        return (this.mirror == end.mirror ? NONE : MIR_NONE).rotate(StructureUtils.getRotationForRotationSteps(rotDiff < 0 ? rotDiff + 4 : rotDiff));
+        for (final RotationMirror rotMir : (this.mirror == end.mirror ? NOT_MIRRORED : MIRRORED))
+        {
+            if (add(rotMir) == end)
+            {
+                return rotMir;
+            }
+        }
+        throw new IllegalStateException("Missing RotationMirror path");
     }
 
     /**

--- a/src/main/java/com/ldtteam/structurize/util/RotationMirror.java
+++ b/src/main/java/com/ldtteam/structurize/util/RotationMirror.java
@@ -1,0 +1,187 @@
+package com.ldtteam.structurize.util;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.gametest.framework.StructureUtils;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
+import net.minecraft.world.phys.Vec3;
+
+/**
+ * Represents all possible states of structure when rorating or mirroring
+ */
+public enum RotationMirror
+{
+    NONE(Rotation.NONE, Mirror.NONE),
+    R90(Rotation.CLOCKWISE_90, Mirror.NONE),
+    R180(Rotation.CLOCKWISE_180, Mirror.NONE),
+    R270(Rotation.COUNTERCLOCKWISE_90, Mirror.NONE),
+    MIR_NONE(Rotation.NONE, Mirror.FRONT_BACK),
+    MIR_R90(Rotation.CLOCKWISE_90, Mirror.FRONT_BACK),
+    MIR_R180(Rotation.CLOCKWISE_180, Mirror.FRONT_BACK),
+    MIR_R270(Rotation.COUNTERCLOCKWISE_90, Mirror.FRONT_BACK);
+
+    static
+    {
+        NONE.rotateCW90 = R90;
+        R90.rotateCW90 = R180;
+        R180.rotateCW90 = R270;
+        R270.rotateCW90 = NONE;
+        MIR_NONE.rotateCW90 = MIR_R90;
+        MIR_R90.rotateCW90 = MIR_R180;
+        MIR_R180.rotateCW90 = MIR_R270;
+        MIR_R270.rotateCW90 = MIR_NONE;
+
+        NONE.rotateCW180 = R180;
+        R90.rotateCW180 = R270;
+        R180.rotateCW180 = NONE;
+        R270.rotateCW180 = R90;
+        MIR_NONE.rotateCW180 = MIR_R180;
+        MIR_R90.rotateCW180 = MIR_R270;
+        MIR_R180.rotateCW180 = MIR_NONE;
+        MIR_R270.rotateCW180 = MIR_R90;
+
+        NONE.rotateCCW90 = R270;
+        R90.rotateCCW90 = NONE;
+        R180.rotateCCW90 = R90;
+        R270.rotateCCW90 = R180;
+        MIR_NONE.rotateCCW90 = MIR_R270;
+        MIR_R90.rotateCCW90 = MIR_NONE;
+        MIR_R180.rotateCCW90 = MIR_R90;
+        MIR_R270.rotateCCW90 = MIR_R180;
+
+        NONE.mirrorFB = MIR_NONE;
+        R90.mirrorFB = MIR_R90;
+        R180.mirrorFB = MIR_R180;
+        R270.mirrorFB = MIR_R270;
+        MIR_NONE.mirrorFB = NONE;
+        MIR_R90.mirrorFB = R90;
+        MIR_R180.mirrorFB = R180;
+        MIR_R270.mirrorFB = R270;
+
+        NONE.mirrorLR = MIR_R180;
+        R90.mirrorLR = MIR_R270;
+        R180.mirrorLR = MIR_NONE;
+        R270.mirrorLR = MIR_R90;
+        MIR_NONE.mirrorLR = R180;
+        MIR_R90.mirrorLR = R270;
+        MIR_R180.mirrorLR = NONE;
+        MIR_R270.mirrorLR = R90;
+    }
+
+    private final Rotation rotation;
+    private final Mirror mirror;
+
+    private RotationMirror rotateCW90;
+    private RotationMirror rotateCW180;
+    private RotationMirror rotateCCW90;
+    private RotationMirror mirrorFB;
+    private RotationMirror mirrorLR;
+
+    private RotationMirror(final Rotation rotation, final Mirror mirror)
+    {
+        this.rotation = rotation;
+        this.mirror = mirror;
+    }
+
+    public Rotation rotation()
+    {
+        return rotation;
+    }
+
+    public Mirror mirror()
+    {
+        return mirror;
+    }
+
+    public RotationMirror rotate(final Rotation by)
+    {
+        return switch (by)
+        {
+            case CLOCKWISE_90 -> rotateCW90;
+            case CLOCKWISE_180 -> rotateCW180;
+            case COUNTERCLOCKWISE_90 -> rotateCCW90;
+            case NONE -> this;
+        };
+    }
+
+    public RotationMirror mirrorate()
+    {
+        return mirrorate(Mirror.FRONT_BACK);
+    }
+
+    /**
+     * @see #mirrorate()
+     */
+    public RotationMirror mirrorate(final Mirror mirrorIn)
+    {
+        return switch (mirrorIn)
+        {
+            case LEFT_RIGHT -> mirrorLR;
+            case FRONT_BACK -> mirrorFB;
+            case NONE -> this;
+        };
+    }
+
+    public static RotationMirror of(final Rotation rotation, final Mirror mirror)
+    {
+        return NONE.mirrorate(mirror).rotate(rotation);
+    }
+
+    /**
+     * @param pos position to transform
+     * @return transformed position using this rot+mir around zero pivot
+     */
+    public BlockPos applyToPos(final BlockPos pos)
+    {
+        return applyToPos(pos, BlockPos.ZERO);
+    }
+
+    /**
+     * @param pos position to transform
+     * @param pivot center of transformation
+     * @return transformed position using this rot+mir around given pivot
+     */
+    public BlockPos applyToPos(final BlockPos pos, final BlockPos pivot)
+    {
+        return StructureTemplate.transform(pos, mirror, rotation, pivot);
+    }
+
+    /**
+     * @param pos position to transform
+     * @return transformed position using this rot+mir around zero pivot
+     */
+    public Vec3 applyToPos(final Vec3 pos)
+    {
+        return applyToPos(pos, BlockPos.ZERO);
+    }
+
+    /**
+     * @param pos position to transform
+     * @param pivot center of transformation
+     * @return transformed position using this rot+mir around given pivot
+     */
+    public Vec3 applyToPos(final Vec3 pos, final BlockPos pivot)
+    {
+        return StructureTemplate.transform(pos, mirror, rotation, pivot);
+    }
+
+    /**
+     * @param  end in which state we should end
+     * @return     end - this = what it takes from this to end
+     */
+    public RotationMirror calcDifferenceTowards(final RotationMirror end)
+    {
+        final int rotDiff =
+            StructureUtils.getRotationStepsForRotation(end.rotation) - StructureUtils.getRotationStepsForRotation(this.rotation);
+        return (this.mirror == end.mirror ? NONE : MIR_NONE).rotate(StructureUtils.getRotationForRotationSteps(rotDiff < 0 ? rotDiff + 4 : rotDiff));
+    }
+
+    /**
+     * @see #calcDifferenceTowards(RotationMirror)
+     */
+    public RotationMirror add(final RotationMirror other)
+    {
+        return this.mirrorate(other.mirror).rotate(other.rotation);
+    }
+}

--- a/src/test/java/com/ldtteam/structurize/util/RotationMirrorTest.java
+++ b/src/test/java/com/ldtteam/structurize/util/RotationMirrorTest.java
@@ -7,7 +7,7 @@ import static org.junit.Assert.assertEquals;
 public class RotationMirrorTest
 {
     @Test
-    public void testCaclDifferenceTowards()
+    public void testCalcDifferenceTowards()
     {
         for (final RotationMirror start : RotationMirror.values())
         {

--- a/src/test/java/com/ldtteam/structurize/util/RotationMirrorTest.java
+++ b/src/test/java/com/ldtteam/structurize/util/RotationMirrorTest.java
@@ -1,0 +1,20 @@
+package com.ldtteam.structurize.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class RotationMirrorTest
+{
+    @Test
+    public void testCaclDifferenceTowards()
+    {
+        for (final RotationMirror start : RotationMirror.values())
+        {
+            for (final RotationMirror end : RotationMirror.values())
+            {
+                assertEquals(end, start.add(start.calcDifferenceTowards(end)));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Supersedes, closes #592
Closes #389 
Closes ldtteam/minecolonies#8719

### Please test in mcol it actually fixes the issues (did test structurize alone and was working fine)

# Changes proposed in this pull request:
- Bumps forge/mc requirements (1.20 not accepted)
- Replaces renderers cache with guava impl, hopefully won't burn like last time, also slightly adjust renderer hashing
- Introduces RotationMirror in favor of deprecated PlacementSettings 
_(the only useful remnant from struct 2.0 xd)_
- Does NOT replace every usage of PlacementSettings though, will do on next vanilla major

Review please 
