### PR TITLE
Allow blueprint handlers to become "mutually exclusive"

### DIFF
--- a/src/main/java/com/ldtteam/structurize/client/gui/AbstractBlueprintManipulationWindow.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/AbstractBlueprintManipulationWindow.java
@@ -139,7 +139,7 @@ public abstract class AbstractBlueprintManipulationWindow extends AbstractWindow
                 if (handlers.isEmpty())
                 {
                     Utils.playErrorSound(Minecraft.getInstance().player);
-                    if (SurvivalBlueprintHandlers.getHandlers().isEmpty())
+                    if (SurvivalBlueprintHandlers.noHandlers())
                     {
                         Minecraft.getInstance().player.displayClientMessage(Component.translatable("structurize.gui.no.survival.handler"), false);
                     }

--- a/src/main/java/com/ldtteam/structurize/storage/SurvivalBlueprintHandlers.java
+++ b/src/main/java/com/ldtteam/structurize/storage/SurvivalBlueprintHandlers.java
@@ -1,6 +1,5 @@
 package com.ldtteam.structurize.storage;
 
-import com.google.common.collect.ImmutableList;
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
 import com.ldtteam.structurize.util.PlacementSettings;
 import net.minecraft.client.multiplayer.ClientLevel;
@@ -23,12 +22,13 @@ public class SurvivalBlueprintHandlers
     private static final Map<String, ISurvivalBlueprintHandler> handlers = new HashMap<>();
 
     /**
-     * Our immutable list of survival handlers, internal use only.
+     * List of lists of mutually exclusive handlers.
      */
-    private static ImmutableList<ISurvivalBlueprintHandler> survivalHandlers = ImmutableList.of();
+    private static final Map<String, List<String>> mutuallyExclusiveHandlers = new HashMap<>();
 
     /**
      * Get a specific handler by id.
+     *
      * @param id the id of the handler.
      * @return the handler instance.
      */
@@ -38,35 +38,94 @@ public class SurvivalBlueprintHandlers
     }
 
     /**
-     * Getthe full list of handlers.
-     * @return a list.
+     * Check if there are no registered handlers.
+     *
+     * @return true if no handlers are present.
      */
-    public static List<ISurvivalBlueprintHandler> getHandlers()
+    public static boolean noHandlers()
     {
-        return survivalHandlers;
+        return handlers.isEmpty();
     }
 
     /**
      * Register a new survival blueprint handler.
+     *
      * @param handler the handler itself.
      */
     public static void registerHandler(final ISurvivalBlueprintHandler handler)
     {
         handlers.put(handler.getId(), handler);
-        survivalHandlers = ImmutableList.copyOf(handlers.values());
+    }
+
+    /**
+     * Register a new survival blueprint handler.
+     * These handlers are "mutually exclusive", meaning that during a call for placement,
+     * only one of these (whichever is hit first) is used for the placement.
+     *
+     * @param blueprintHandlers the blueprint handlers.
+     */
+    public static void registerMutuallyExclusiveHandler(final ISurvivalBlueprintHandler... blueprintHandlers)
+    {
+        List<String> handlerIds = new ArrayList<>();
+
+        for (final ISurvivalBlueprintHandler blueprintHandler : blueprintHandlers)
+        {
+            handlers.put(blueprintHandler.getId(), blueprintHandler);
+            mutuallyExclusiveHandlers.put(blueprintHandler.getId(), new ArrayList<>());
+            handlerIds.add(blueprintHandler.getId());
+        }
+
+        for (final String handlerId : handlerIds)
+        {
+            for (final String otherHandlerId : handlerIds)
+            {
+                if (!handlerId.equals(otherHandlerId))
+                {
+                    mutuallyExclusiveHandlers.get(handlerId).add(otherHandlerId);
+                }
+            }
+        }
     }
 
     /**
      * Get all handlers that can take over the placement operation.
-     * @return
+     *
+     * @return the list of matching handlers.
      */
-    public static List<ISurvivalBlueprintHandler> getMatchingHandlers(final Blueprint blueprint, final ClientLevel level, final Player player, final BlockPos pos, final PlacementSettings settings)
+    public static List<ISurvivalBlueprintHandler> getMatchingHandlers(
+      final Blueprint blueprint,
+      final ClientLevel level,
+      final Player player,
+      final BlockPos pos,
+      final PlacementSettings settings)
     {
+        final List<String> matchingHandlerIds = new ArrayList<>();
         final List<ISurvivalBlueprintHandler> matchingHandlers = new ArrayList<>();
+
         for (final ISurvivalBlueprintHandler handler : handlers.values())
         {
+            boolean shouldSkip = false;
+            final List<String> mutuallyExclusives = mutuallyExclusiveHandlers.get(handler.getId());
+            if (mutuallyExclusives != null)
+            {
+                for (final String otherHandlerId : mutuallyExclusives)
+                {
+                    if (matchingHandlerIds.contains(otherHandlerId))
+                    {
+                        shouldSkip = true;
+                        break;
+                    }
+                }
+            }
+
+            if (shouldSkip)
+            {
+                continue;
+            }
+
             if (handler.canHandle(blueprint, level, player, pos, settings))
             {
+                matchingHandlerIds.add(handler.getId());
                 matchingHandlers.add(handler);
             }
         }


### PR DESCRIPTION
# Changes proposed in this pull request:
- Blueprint handlers can be registered as mutually exclusive, this would mean only one of the handlers can be used simultaneously for placement.
- A use case for this is currently in Minecolonies, where we have 2 placement handlers for the plantation fields and the regular SurvivalHandler. The SurvivalHandler requires extra code to ensure there are no 2 "Assign to builder" buttons, this is because the SurvivalHandler can handle placement of anything, provided it is within colony borders.
Using this, that is not needed anymore, if the plantation field handler is defined first and the block is a plantation field, that one will be selected and the survival handler can then simply not be selected anymore.

Review please
