### PR TITLE
Fix facing when mirroring

### DIFF
--- a/src/main/java/com/ldtteam/structurize/blueprints/FacingFixer.java
+++ b/src/main/java/com/ldtteam/structurize/blueprints/FacingFixer.java
@@ -25,14 +25,14 @@ public record FacingFixer(Predicate<BlockState> test, DirectionProperty property
 {
     public static final List<FacingFixer> MIRROR_FIXERS = new ArrayList<>();
 
-    public static final FacingFixer GLAZED_TERRACOTA_SPECIAL = mirror(bs -> bs.getBlock() == Blocks.LIGHT_GRAY_GLAZED_TERRACOTTA ||
+    public static final FacingFixer GLAZED_TERRACOTA_SPECIAL = mirrorFixer(bs -> bs.getBlock() == Blocks.LIGHT_GRAY_GLAZED_TERRACOTTA ||
             bs.getBlock() == Blocks.PINK_GLAZED_TERRACOTTA ||
             bs.getBlock() == Blocks.BLUE_GLAZED_TERRACOTTA ||
             bs.getBlock() == Blocks.CYAN_GLAZED_TERRACOTTA,
         GlazedTerracottaBlock.FACING,
         FacingMapping.SOUTH_EAST_AND_NORTH_WEST);
 
-    public static final FacingFixer GLAZED_TERRACOTA_MAJORITY = mirror(bs -> bs.getBlock() instanceof GlazedTerracottaBlock &&
+    public static final FacingFixer GLAZED_TERRACOTA_MAJORITY = mirrorFixer(bs -> bs.getBlock() instanceof GlazedTerracottaBlock &&
             bs.getBlock() != Blocks.MAGENTA_GLAZED_TERRACOTTA,
         GlazedTerracottaBlock.FACING,
         FacingMapping.NORTH_EAST_AND_SOUTH_WEST);
@@ -44,7 +44,7 @@ public record FacingFixer(Predicate<BlockState> test, DirectionProperty property
      * @return fixer registered as mirror fixer
      * @see #MIRROR_FIXERS
      */
-    public static FacingFixer mirror(final Predicate<BlockState> test, final DirectionProperty property, final Function<Direction, Direction> mapping)
+    public static FacingFixer mirrorFixer(final Predicate<BlockState> test, final DirectionProperty property, final Function<Direction, Direction> mapping)
     {
         final FacingFixer result = new FacingFixer(test, property, mapping);
         MIRROR_FIXERS.add(result);

--- a/src/main/java/com/ldtteam/structurize/blueprints/FacingFixer.java
+++ b/src/main/java/com/ldtteam/structurize/blueprints/FacingFixer.java
@@ -1,0 +1,98 @@
+package com.ldtteam.structurize.blueprints;
+
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.GlazedTerracottaBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.DirectionProperty;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static net.minecraft.core.Direction.DOWN;
+import static net.minecraft.core.Direction.EAST;
+import static net.minecraft.core.Direction.NORTH;
+import static net.minecraft.core.Direction.SOUTH;
+import static net.minecraft.core.Direction.UP;
+import static net.minecraft.core.Direction.WEST;
+
+/**
+ * Used during mirroring of blueprint palette
+ */
+
+public record FacingFixer(Predicate<BlockState> test, DirectionProperty property, Function<Direction, Direction> mapping)
+{
+    public static final List<FacingFixer> MIRROR_FIXERS = new ArrayList<>();
+
+    public static final FacingFixer GLAZED_TERRACOTA_SPECIAL = mirror(bs -> bs.getBlock() == Blocks.LIGHT_GRAY_GLAZED_TERRACOTTA ||
+            bs.getBlock() == Blocks.PINK_GLAZED_TERRACOTTA ||
+            bs.getBlock() == Blocks.BLUE_GLAZED_TERRACOTTA ||
+            bs.getBlock() == Blocks.CYAN_GLAZED_TERRACOTTA,
+        GlazedTerracottaBlock.FACING,
+        FacingMapping.SOUTH_EAST_AND_NORTH_WEST);
+
+    public static final FacingFixer GLAZED_TERRACOTA_MAJORITY = mirror(bs -> bs.getBlock() instanceof GlazedTerracottaBlock &&
+            bs.getBlock() != Blocks.MAGENTA_GLAZED_TERRACOTTA,
+        GlazedTerracottaBlock.FACING,
+        FacingMapping.NORTH_EAST_AND_SOUTH_WEST);
+
+    /**
+     * @param test to which blocks should fixer apply
+     * @param property which property is being fixed
+     * @param mapping fix function
+     * @return fixer registered as mirror fixer
+     * @see #MIRROR_FIXERS
+     */
+    public static FacingFixer mirror(final Predicate<BlockState> test, final DirectionProperty property, final Function<Direction, Direction> mapping)
+    {
+        final FacingFixer result = new FacingFixer(test, property, mapping);
+        MIRROR_FIXERS.add(result);
+        return result;
+    }
+
+    /**
+     * @param blockstate after applying mirror
+     * @param unmirrored before applying mirror
+     * @return using first matching fixer fixes the blockstate property
+     * @see #MIRROR_FIXERS
+     */
+    public static BlockState fixMirroredFacing(final BlockState blockstate, final BlockState unmirrored)
+    {
+        for (final FacingFixer fixer : MIRROR_FIXERS)
+        {
+            if (fixer.test.test(blockstate))
+            {
+                return blockstate.setValue(fixer.property, fixer.mapping.apply(unmirrored.getValue(fixer.property)));
+            }
+        }
+
+        return blockstate;
+    }
+
+    public record FacingMapping(Direction north, Direction east, Direction south, Direction west, Direction up, Direction down) implements Function<Direction, Direction>
+    {
+        public static final FacingMapping NORTH_EAST_AND_SOUTH_WEST = new FacingMapping(EAST, NORTH, WEST, SOUTH);
+        public static final FacingMapping SOUTH_EAST_AND_NORTH_WEST = new FacingMapping(WEST, SOUTH, EAST, NORTH);
+        public static final FacingMapping KEEP_ORIGINAL = new FacingMapping(NORTH, EAST, SOUTH, WEST);
+    
+        public FacingMapping(final Direction north, final Direction east, final Direction south, final Direction west)
+        {
+            this(north, east, south, west, UP, DOWN);
+        }
+    
+        @Override
+        public Direction apply(final Direction direction)
+        {
+            return switch (direction)
+            {
+                case NORTH -> north;
+                case EAST -> east;
+                case SOUTH -> south;
+                case WEST -> west;
+                case UP -> up;
+                case DOWN -> down;
+            };
+        }
+    }
+}

--- a/src/main/java/com/ldtteam/structurize/blueprints/v1/Blueprint.java
+++ b/src/main/java/com/ldtteam/structurize/blueprints/v1/Blueprint.java
@@ -7,6 +7,7 @@ import com.ldtteam.structurize.blockentities.BlockEntityTagSubstitution;
 import com.ldtteam.structurize.blockentities.ModBlockEntities;
 import com.ldtteam.structurize.blocks.ModBlocks;
 import com.ldtteam.structurize.blocks.interfaces.IAnchorBlock;
+import com.ldtteam.structurize.blueprints.FacingFixer;
 import com.ldtteam.structurize.blockentities.interfaces.IBlueprintDataProviderBE;
 import com.ldtteam.structurize.util.BlockInfo;
 import com.ldtteam.structurize.util.BlockUtils;
@@ -420,6 +421,14 @@ public class Blueprint
     }
 
     /**
+     * @return current rot/mir as relative to freshly loaded file
+     */
+    public RotationMirror getRotationMirror()
+    {
+        return rotationMirror;
+    }
+
+    /**
      * Get a list of all entities in the blueprint as a list.
      *
      * @return the list of CompoundNBTs.
@@ -653,7 +662,14 @@ public class Blueprint
         final List<BlockState> palette = new ArrayList<>();
         for (int i = 0; i < this.palette.size(); i++)
         {
-            palette.add(i, this.palette.get(i).mirror(transformBy.mirror()).rotate(transformBy.rotation()));
+            BlockState bs = this.palette.get(i).mirror(transformBy.mirror());
+
+            if (transformBy.isMirrored())
+            {
+                bs = FacingFixer.fixMirroredFacing(bs, this.palette.get(i));
+            }
+
+            palette.add(i, bs.rotate(transformBy.rotation()));
         }
 
         final BlockPos extremes = transformBy.applyToPos(new BlockPos(sizeX, sizeY, sizeZ));

--- a/src/main/java/com/ldtteam/structurize/blueprints/v1/Blueprint.java
+++ b/src/main/java/com/ldtteam/structurize/blueprints/v1/Blueprint.java
@@ -662,11 +662,11 @@ public class Blueprint
         final List<BlockState> palette = new ArrayList<>();
         for (int i = 0; i < this.palette.size(); i++)
         {
-            BlockState bs = this.palette.get(i).mirror(transformBy.mirror());
+            BlockState bs = this.palette.get(i);
 
             if (transformBy.isMirrored())
             {
-                bs = FacingFixer.fixMirroredFacing(bs, this.palette.get(i));
+                bs = FacingFixer.fixMirroredFacing(bs.mirror(transformBy.mirror()), this.palette.get(i));
             }
 
             palette.add(i, bs.rotate(transformBy.rotation()));

--- a/src/main/java/com/ldtteam/structurize/blueprints/v1/Blueprint.java
+++ b/src/main/java/com/ldtteam/structurize/blueprints/v1/Blueprint.java
@@ -666,7 +666,7 @@ public class Blueprint
 
             if (transformBy.isMirrored())
             {
-                bs = FacingFixer.fixMirroredFacing(bs.mirror(transformBy.mirror()), this.palette.get(i));
+                bs = FacingFixer.fixMirroredFacing(bs.mirror(transformBy.mirror()), bs);
             }
 
             palette.add(i, bs.rotate(transformBy.rotation()));

--- a/src/main/java/com/ldtteam/structurize/util/RotationMirror.java
+++ b/src/main/java/com/ldtteam/structurize/util/RotationMirror.java
@@ -91,6 +91,11 @@ public enum RotationMirror
         return rotation;
     }
 
+    public boolean isMirrored()
+    {
+        return mirror != Mirror.NONE;
+    }
+
     public Mirror mirror()
     {
         return mirror;


### PR DESCRIPTION
# Changes proposed in this pull request:
- add mechanism to fix HorizontalDirectionalBlock not being able to handle 8-directional textures/blocks correctly
- ideally our 8-dirs ("F" shapes) should create new facing backed by rotmir enum

Review please
