### PR TITLE
Back to the custom names 1.20

### DIFF
--- a/src/main/java/com/ldtteam/structurize/blueprints/v1/BlueprintTagUtils.java
+++ b/src/main/java/com/ldtteam/structurize/blueprints/v1/BlueprintTagUtils.java
@@ -2,15 +2,19 @@ package com.ldtteam.structurize.blueprints.v1;
 
 import com.ldtteam.structurize.blockentities.interfaces.IBlueprintDataProviderBE;
 
+import com.ldtteam.structurize.blocks.interfaces.IInvisibleBlueprintAnchorBlock;
+import com.ldtteam.structurize.util.BlockInfo;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static com.ldtteam.structurize.api.util.constant.Constants.GROUNDLEVEL_TAG;
+import static com.ldtteam.structurize.api.util.constant.Constants.INVISIBLE_TAG;
 import static com.ldtteam.structurize.blockentities.interfaces.IBlueprintDataProviderBE.TAG_BLUEPRINTDATA;
 
 /**
@@ -35,6 +39,28 @@ public class BlueprintTagUtils
         }
 
         return new HashMap<>();
+    }
+
+    /**
+     * A blueprint may hide itself from the build tool list in one of two ways:
+     * 1. the anchor block implements IInvisibleBlueprintAnchorBlock and returns true when asked
+     * 2. the anchor block implements IBlueprintDataProviderBE and is directly tagged "invisible"
+     *
+     * @param blueprint the blueprint to check
+     * @return true if this blueprint should be hidden from normal players
+     */
+    public static boolean isInvisible(final Blueprint blueprint)
+    {
+        final BlockInfo anchor = blueprint.getBlockInfoAsMap().get(blueprint.getPrimaryBlockOffset());
+        if (anchor.getState().getBlock() instanceof IInvisibleBlueprintAnchorBlock invis &&
+                !invis.isVisible(anchor.getTileEntityData()))
+        {
+            return true;
+        }
+
+        final Map<BlockPos, List<String>> tagPosMap = BlueprintTagUtils.getBlueprintTags(blueprint);
+        final List<String> anchorTags = tagPosMap.computeIfAbsent(BlockPos.ZERO, k -> new ArrayList<>());
+        return anchorTags.contains(INVISIBLE_TAG);
     }
 
     /**

--- a/src/main/java/com/ldtteam/structurize/blueprints/v1/BlueprintTagUtils.java
+++ b/src/main/java/com/ldtteam/structurize/blueprints/v1/BlueprintTagUtils.java
@@ -6,6 +6,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -18,6 +19,25 @@ import static com.ldtteam.structurize.blockentities.interfaces.IBlueprintDataPro
 public class BlueprintTagUtils
 {
     /**
+     * Gets the tag map from the given blueprint.
+     *
+     * @param blueprint the blueprint
+     * @return          the tag map, relative to the anchor block
+     */
+    public static Map<BlockPos, List<String>> getBlueprintTags(final Blueprint blueprint)
+    {
+        final BlockPos anchorPos = blueprint.getPrimaryBlockOffset();
+        final CompoundTag nbt = blueprint.getBlockInfoAsMap().get(anchorPos).getTileEntityData();
+
+        if (nbt != null)
+        {
+            return IBlueprintDataProviderBE.readTagPosMapFrom(nbt.getCompound(TAG_BLUEPRINTDATA));
+        }
+
+        return new HashMap<>();
+    }
+
+    /**
      * Get the first pos for the given tag
      *
      * @param blueprint rotated/mirrored blueprint
@@ -26,19 +46,15 @@ public class BlueprintTagUtils
      */
     public static BlockPos getFirstPosForTag(final Blueprint blueprint, final String tagName)
     {
-        final BlockPos anchorPos = blueprint.getPrimaryBlockOffset();
-        final CompoundTag nbt = blueprint.getBlockInfoAsMap().get(anchorPos).getTileEntityData();
-        if (nbt != null)
+        final Map<BlockPos, List<String>> tagPosMap = getBlueprintTags(blueprint);
+
+        for (final Map.Entry<BlockPos, List<String>> entry : tagPosMap.entrySet())
         {
-            final Map<BlockPos, List<String>> tagPosMap = IBlueprintDataProviderBE.readTagPosMapFrom(nbt.getCompound(TAG_BLUEPRINTDATA));
-            for (final Map.Entry<BlockPos, List<String>> entry : tagPosMap.entrySet())
+            for (final String tag : entry.getValue())
             {
-                for (final String tag : entry.getValue())
+                if (tag.equals(tagName))
                 {
-                    if (tag.equals(tagName))
-                    {
-                        return entry.getKey();
-                    }
+                    return entry.getKey();
                 }
             }
         }

--- a/src/main/java/com/ldtteam/structurize/blueprints/v1/BlueprintTagUtils.java
+++ b/src/main/java/com/ldtteam/structurize/blueprints/v1/BlueprintTagUtils.java
@@ -7,6 +7,7 @@ import com.ldtteam.structurize.util.BlockInfo;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -58,8 +59,7 @@ public class BlueprintTagUtils
             return true;
         }
 
-        final Map<BlockPos, List<String>> tagPosMap = getBlueprintTags(blueprint);
-        final List<String> anchorTags = tagPosMap.computeIfAbsent(BlockPos.ZERO, k -> new ArrayList<>());
+        final List<String> anchorTags = getBlueprintTags(blueprint).computeIfAbsent(BlockPos.ZERO, k -> new ArrayList<>());
         return anchorTags.contains(INVISIBLE_TAG);
     }
 
@@ -70,6 +70,7 @@ public class BlueprintTagUtils
      * @param tagName   tag name
      * @return found position or null
      */
+    @Nullable
     public static BlockPos getFirstPosForTag(final Blueprint blueprint, final String tagName)
     {
         final Map<BlockPos, List<String>> tagPosMap = getBlueprintTags(blueprint);

--- a/src/main/java/com/ldtteam/structurize/blueprints/v1/BlueprintTagUtils.java
+++ b/src/main/java/com/ldtteam/structurize/blueprints/v1/BlueprintTagUtils.java
@@ -58,7 +58,7 @@ public class BlueprintTagUtils
             return true;
         }
 
-        final Map<BlockPos, List<String>> tagPosMap = BlueprintTagUtils.getBlueprintTags(blueprint);
+        final Map<BlockPos, List<String>> tagPosMap = getBlueprintTags(blueprint);
         final List<String> anchorTags = tagPosMap.computeIfAbsent(BlockPos.ZERO, k -> new ArrayList<>());
         return anchorTags.contains(INVISIBLE_TAG);
     }

--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowExtendedBuildTool.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowExtendedBuildTool.java
@@ -434,7 +434,7 @@ public final class WindowExtendedBuildTool extends AbstractBlueprintManipulation
                                 nextDepthMeta.put(id, StructurePacks.getCategoriesFuture(structurePack.getName(), id));
                             }
                         }
-                        updateFolders(subCats);
+                        updateFolders(subCats, null);
                         nextDepth = "";
                     }
                 }
@@ -491,7 +491,7 @@ public final class WindowExtendedBuildTool extends AbstractBlueprintManipulation
      *
      * @param inputCategories the categories to render now.
      */
-    public void updateFolders(final List<StructurePacks.Category> inputCategories)
+    public void updateFolders(final List<StructurePacks.Category> inputCategories, final String prevCat)
     {
         folderList.enable();
         folderList.show();
@@ -510,6 +510,10 @@ public final class WindowExtendedBuildTool extends AbstractBlueprintManipulation
                 parentCat = nextDepth.replace("/" + currentCat, "");
             }
             categories.add(new ButtonData(ButtonType.Back, parentCat));
+        }
+        else if (prevCat != null)
+        {
+            categories.add(new ButtonData(ButtonType.Back, prevCat));
         }
 
         for (final StructurePacks.Category category : inputCategories)
@@ -979,7 +983,7 @@ public final class WindowExtendedBuildTool extends AbstractBlueprintManipulation
         if (button.getID().contains("back:"))
         {
             nextDepth = button.getID().split(":").length == 1 ? "" : button.getID().split(":")[1];
-            updateFolders(Collections.emptyList());
+            updateFolders(Collections.emptyList(), null);
             updateBlueprints(Collections.emptyList(), "");
             depth = nextDepth;
             if (depth.isEmpty())
@@ -996,7 +1000,7 @@ public final class WindowExtendedBuildTool extends AbstractBlueprintManipulation
         else if (nextDepthMeta.containsKey(button.getID()))
         {
             nextDepth = button.getID();
-            updateFolders(Collections.emptyList());
+            updateFolders(Collections.emptyList(), null);
             updateBlueprints(Collections.emptyList(), "");
             depth = nextDepth;
             findPaneOfTypeByID("tree", Text.class).setText(Component.literal(structurePack.getName() + "/" + nextDepth).setStyle(Style.EMPTY.withBold(true)));
@@ -1017,7 +1021,7 @@ public final class WindowExtendedBuildTool extends AbstractBlueprintManipulation
         else if (blueprintsAtDepth.containsKey(button.getID()))
         {
             nextDepth = button.getID();
-            updateFolders(Collections.emptyList());
+            updateFolders(Collections.emptyList(), null);
             updateBlueprints(Collections.emptyList(), "");
             depth = nextDepth;
             findPaneOfTypeByID("tree", Text.class).setText(Component.literal(structurePack.getName() + "/" + nextDepth).setStyle(Style.EMPTY.withBold(true)));
@@ -1155,7 +1159,7 @@ public final class WindowExtendedBuildTool extends AbstractBlueprintManipulation
         {
             Log.getLogger().error("Invalid blueprint name at depth: " + categoryId);
         }
-        updateFolders(Collections.emptyList());
+        updateFolders(Collections.emptyList(), split[0]);
     }
 
     private void setBlueprint(Blueprint blueprint)

--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowExtendedBuildTool.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowExtendedBuildTool.java
@@ -920,8 +920,7 @@ public final class WindowExtendedBuildTool extends AbstractBlueprintManipulation
         if (nameTag.isPresent())
         {
             final String name = nameTag.get().substring(5);
-            return new DisplayNames(name, Component.literal(name),
-                    Collections.singletonList(Component.literal(blueprint.getFileName())));
+            return new DisplayNames(name, Component.literal(name), Collections.emptyList());
         }
         else if (anchor.getBlock() instanceof INamedBlueprintAnchorBlock namedAnchor)
         {
@@ -931,7 +930,7 @@ public final class WindowExtendedBuildTool extends AbstractBlueprintManipulation
         else
         {
             return new DisplayNames(blueprint.getFileName(),
-                    Component.literal(blueprint.getFileName()), new ArrayList<>());
+                    Component.literal(blueprint.getFileName()), Collections.emptyList());
         }
     }
 


### PR DESCRIPTION
Closes [discord request](https://discord.com/channels/472875599422291968/1156041864433107014)

# Changes proposed in this pull request:
- If the anchor block has a `name=Something` tag (directly on itself), this name will be used in place of the blueprint's filename.
    - This is primarily intended to give nicer names to decorations that would otherwise just appear as their (possibly numbered) filename, but it can also be used to override the "alternates" name shown for MineColonies buildings.
    - The tag must be used consistently at all levels of the blueprint, otherwise they will "split".
    - There is currently no way to translate this name, but that's not different from existing behaviour.  A translation PR will follow.
- When you click on a blueprint button that has alternatives and/or levels, previously the list of folders/blueprints at the bottom was completely cleared.  Now, a back button remains, allowing you to return to the list of blueprints that was visible previously, to allow quickly inspecting in and out of related buildings.
- The `isInvisible` check has been extracted to a utility method since MineColonies wants to be able to call it too.

Review please (could port)

This is a port of #614 but it has a different implementation that doesn't override the building name.