### PR TITLE
Fix icon

### DIFF
--- a/src/main/resources/assets/structurize/gui/windowswitchpack.xml
+++ b/src/main/resources/assets/structurize/gui/windowswitchpack.xml
@@ -26,7 +26,7 @@
                         texthovercolor="gray"/>
             </box>
             <box size="200 100" linewidth="0" pos="200 0" id="box2">
-                <image id="icon2" pos="0 0" size="80 80" source="structurize:textures/items/sceptersteel.png"/>
+                <image id="icon2" pos="0 0" size="80 80" source="structurize:textures/item/sceptersteel.png"/>
 
                 <text id="name2" pos="81 0" size="119 17" color="white" textscale="1.2"/>
                 <text id="desc2" pos="81 20" size="119 50" color="white" textscale="0.6"/>


### PR DESCRIPTION
# Changes proposed in this pull request:
- Fixes icon rendering error in "Select Pack" window

Review please (do not backport)

```
[Render thread/WARN] [minecraft/TextureManager]: Failed to load texture: structurize:textures/items/sceptersteel.png
java.io.FileNotFoundException: structurize:textures/items/sceptersteel.png
	at net.minecraft.server.packs.resources.ResourceProvider.lambda$getResourceOrThrow$0(ResourceProvider.java:17) ~[forge-1.20.1-47.1.3_mapped_official_1.20.1-recomp.jar:?] {re:classloading}
	at java.util.Optional.orElseThrow(Optional.java:403) ~[?:?] {}
	at net.minecraft.server.packs.resources.ResourceProvider.getResourceOrThrow(ResourceProvider.java:16) ~[forge-1.20.1-47.1.3_mapped_official_1.20.1-recomp.jar:?] {re:classloading}
	at net.minecraft.client.renderer.texture.SimpleTexture$TextureImage.load(SimpleTexture.java:85) ~[forge-1.20.1-47.1.3_mapped_official_1.20.1-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.renderer.texture.SimpleTexture.getTextureImage(SimpleTexture.java:59) ~[forge-1.20.1-47.1.3_mapped_official_1.20.1-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.renderer.texture.SimpleTexture.load(SimpleTexture.java:29) ~[forge-1.20.1-47.1.3_mapped_official_1.20.1-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.renderer.texture.TextureManager.loadTexture(TextureManager.java:96) ~[forge-1.20.1-47.1.3_mapped_official_1.20.1-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.renderer.texture.TextureManager.register(TextureManager.java:66) ~[forge-1.20.1-47.1.3_mapped_official_1.20.1-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.renderer.texture.TextureManager._bind(TextureManager.java:59) ~[forge-1.20.1-47.1.3_mapped_official_1.20.1-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.client.renderer.texture.TextureManager.bindForSetup(TextureManager.java:50) ~[forge-1.20.1-47.1.3_mapped_official_1.20.1-recomp.jar:?] {re:classloading,pl:runtimedistcleaner:A}
	at com.ldtteam.blockui.UiRenderMacros.blit(UiRenderMacros.java:431) ~[blockui-1.20.1-0.0.101-ALPHA_mapped_official_1.20.1.jar:1.20.1-0.0.101-ALPHA] {re:classloading}
	at com.ldtteam.blockui.UiRenderMacros.blit(UiRenderMacros.java:386) ~[blockui-1.20.1-0.0.101-ALPHA_mapped_official_1.20.1.jar:1.20.1-0.0.101-ALPHA] {re:classloading}
	at com.ldtteam.blockui.controls.Image.drawSelf(Image.java:232) ~[blockui-1.20.1-0.0.101-ALPHA_mapped_official_1.20.1.jar:1.20.1-0.0.101-ALPHA] {re:classloading}
```
