### PR TITLE
Fix versioning for 1.20 with new OPC update

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,6 +33,8 @@ blockUiRange=[1.20.1-0.0.98-ALPHA,)
 domumOrnamentumVersion=1.20.1-1.0.199-BETA
 domumOrnamentumRange=[1.20-1.0.93-ALPHA,)
 
+usesMCVersionOrderFirst=true
+
 githubUrl=https://github.com/ldtteam/Structurize
 gitUrl=https://github.com/ldtteam/Structurize.git
 gitConnectUrl=https://github.com/ldtteam/Structurize.git


### PR DESCRIPTION
See https://github.com/ldtteam/OperaPublicaCreator/pull/30