### PR TITLE
Draft changes for itemHandler

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ javaVersion=21
 useJavaToolChains=true
 
 #The currently running forge.
-forgeVersion=21.1.4
+forgeVersion=21.1.72
 
 fmlRange=[4,)
 forgeRange=[21.0.143,)

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,7 @@ minecraftVersion=1.21.1
 #Comma seperated list of mc versions, which are marked as compatible on curseforge
 additionalMinecraftVersions=1.21
 
-blockUiVersion=1.0.188-1.21.1-snapshot
+blockUiVersion=1.0.191-1.21.1-snapshot
 domumOrnamentumVersion=1.0.203-1.21.1-snapshot
 
 githubUrl=https://github.com/ldtteam/Structurize

--- a/src/main/java/com/ldtteam/structurize/api/ItemStackUtils.java
+++ b/src/main/java/com/ldtteam/structurize/api/ItemStackUtils.java
@@ -9,8 +9,8 @@ import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.decoration.ArmorStand;
 import net.minecraft.world.entity.decoration.ItemFrame;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.SpawnEggItem;
 import net.minecraft.world.level.Level;
@@ -249,16 +249,14 @@ public final class ItemStackUtils
         else if (entity instanceof final ItemFrame itemFrame)
         {
             final ItemStack stack = itemFrame.getItem();
-            if (!ItemStackUtils.isEmpty(stack))
-            {
-                stack.setCount(1);
-                entityContent.add(stack);
-            }
+            entityContent.add(stack);
+            deepExtractItemHandler(stack.getCapability(ItemHandler.ITEM), entityContent::add);
         }
-        else if (entity instanceof final ArmorStand armorStand)
+        else if (entity instanceof final ItemEntity itemEntity)
         {
-            armorStand.getArmorSlots().forEach(entityContent::add);
-            armorStand.getHandSlots().forEach(entityContent::add);
+            final ItemStack stack = itemEntity.getItem();
+            entityContent.add(stack);
+            deepExtractItemHandler(stack.getCapability(ItemHandler.ITEM), entityContent::add);
         }
         else // sided item handler
         {

--- a/src/main/java/com/ldtteam/structurize/api/ItemStackUtils.java
+++ b/src/main/java/com/ldtteam/structurize/api/ItemStackUtils.java
@@ -29,7 +29,7 @@ import java.util.function.Consumer;
  */
 public final class ItemStackUtils
 {
-    private static final SidedSingleBlockFakeLevel itemHandlerFakeLevel = new SidedSingleBlockFakeLevel();
+    public static final SidedSingleBlockFakeLevel ITEM_HANDLER_FAKE_LEVEL = new SidedSingleBlockFakeLevel();
 
     /**
      * Private constructor to hide the implicit one.
@@ -64,9 +64,9 @@ public final class ItemStackUtils
             return List.of();
         }
 
-        return itemHandlerFakeLevel.get(level).useFakeLevelContext(state, tileEntity, level, fakeLevel -> {
+        return ITEM_HANDLER_FAKE_LEVEL.get(level).useFakeLevelContext(state, tileEntity, level, fakeLevel -> {
             final List<ItemStack> items = new ArrayList<>();
-            getItemHandlersFromProvider(tileEntity).forEach(itemHandler -> deepExtractItemHandler(itemHandler, items::add));
+            getItemHandlersFromProvider(tileEntity, blockpos, state).forEach(itemHandler -> deepExtractItemHandler(itemHandler, items::add));
             return items;
         });
     }
@@ -100,7 +100,7 @@ public final class ItemStackUtils
      * @param provider The provider to get the IItemHandlers from.
      * @return A list with all the unique IItemHandlers a provider has.
      */
-    public static Set<IItemHandler> getItemHandlersFromProvider(@Nullable final BlockEntity provider)
+    public static Set<IItemHandler> getItemHandlersFromProvider(@Nullable final BlockEntity provider, final BlockPos pos, final BlockState state)
     {
         if (provider == null)
         {
@@ -117,7 +117,7 @@ public final class ItemStackUtils
             return Set.of(new InvWrapper(container));
         }
 
-        final IItemHandler unsidedItemHandler = ItemHandler.BLOCK.getCapability(provider.getLevel(), provider.getBlockPos(), provider.getBlockState(), provider, null);
+        final IItemHandler unsidedItemHandler = provider.getLevel().getCapability(ItemHandler.BLOCK, pos, state, provider, null);
         if (unsidedItemHandler != null)
         {
             // weak assumption of unsided being partial view only
@@ -127,7 +127,7 @@ public final class ItemStackUtils
         final Set<IItemHandler> handlerSet = new HashSet<>();
         for (final Direction side : Direction.values())
         {
-            final IItemHandler cap = ItemHandler.BLOCK.getCapability(provider.getLevel(), provider.getBlockPos(), provider.getBlockState(), provider, side);
+            final IItemHandler cap = provider.getLevel().getCapability(ItemHandler.BLOCK, pos, state, provider, side);
             if (cap != null)
             {
                 handlerSet.add(cap);

--- a/src/main/java/com/ldtteam/structurize/api/ItemStorage.java
+++ b/src/main/java/com/ldtteam/structurize/api/ItemStorage.java
@@ -190,4 +190,14 @@ public class ItemStorage
     {
         return stack.getDamageValue();
     }
+
+    /**
+     * Adder for the quantity.
+     *
+     * @param amount the amount to be added.
+     */
+    public void addAmount(final int amount)
+    {
+        setAmount(getAmount() + amount);
+    }
 }

--- a/src/main/java/com/ldtteam/structurize/api/constants/WindowConstants.java
+++ b/src/main/java/com/ldtteam/structurize/api/constants/WindowConstants.java
@@ -327,6 +327,8 @@ public final class WindowConstants
      */
     public static final String REMOVE_FILTERED = "removefiltered";
 
+    public static final String BUTTON_CONTENTS = "contents";
+
     /**
      * public constructor to hide implicit public one.
      */

--- a/src/main/java/com/ldtteam/structurize/blueprints/v1/Blueprint.java
+++ b/src/main/java/com/ldtteam/structurize/blueprints/v1/Blueprint.java
@@ -2,6 +2,7 @@ package com.ldtteam.structurize.blueprints.v1;
 
 import com.ldtteam.structurize.api.Log;
 import com.ldtteam.common.fakelevel.IFakeLevelBlockGetter;
+import com.ldtteam.common.util.BlockToItemHelper;
 import com.ldtteam.structurize.api.BlockPosUtil;
 import com.ldtteam.structurize.api.ItemStackUtils;
 import com.ldtteam.structurize.blockentities.BlockEntityTagSubstitution;
@@ -514,8 +515,10 @@ public class Blueprint implements IFakeLevelBlockGetter
      * 
      * @param pos the pos its at.
      * @return an item or null if not initialized.
+     * @deprecated use {@link BlockToItemHelper}
      */
     @Nullable
+    @Deprecated(forRemoval = true, since = "1.21.1")
     public Item getItem(final BlockPos pos)
     {
         @Nullable

--- a/src/main/java/com/ldtteam/structurize/client/BlueprintHandler.java
+++ b/src/main/java/com/ldtteam/structurize/client/BlueprintHandler.java
@@ -7,8 +7,10 @@ import com.ldtteam.structurize.api.Log;
 import com.ldtteam.structurize.storage.rendering.types.BlueprintPreviewData;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.Entity;
 import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -124,5 +126,14 @@ public final class BlueprintHandler
         }
 
         Minecraft.getInstance().getProfiler().pop();
+    }
+
+    /**
+     * @return list of entities for instantiated renderer (potentially immediately invalid), else empty list
+     */
+    public List<Entity> getOptionalEntitiesForBlueprint(final BlueprintPreviewData previewData)
+    {
+        final BlueprintRenderer renderer = rendererCache.getIfPresent(previewData.getRenderKey());
+        return renderer == null ? List.of() : renderer.entities;
     }
 }

--- a/src/main/java/com/ldtteam/structurize/client/BlueprintRenderer.java
+++ b/src/main/java/com/ldtteam/structurize/client/BlueprintRenderer.java
@@ -94,7 +94,7 @@ public class BlueprintRenderer implements AutoCloseable
     private static boolean hasWarnedExceptions = false;
 
     private final BlueprintBlockAccess blockAccess;
-    private List<Entity> entities;
+    List<Entity> entities = List.of();
     private List<BlockEntity> tileEntities;
     private Map<RenderType, VertexBuffer> vertexBuffers;
     private long lastGameTime;

--- a/src/main/java/com/ldtteam/structurize/client/gui/AbstractBlueprintManipulationWindow.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/AbstractBlueprintManipulationWindow.java
@@ -548,7 +548,7 @@ public abstract class AbstractBlueprintManipulationWindow extends AbstractWindow
     private void openContents()
     {
         final BlueprintPreviewData previewData = RenderingCache.getOrCreateBlueprintPreviewData(bluePrintId);
-        new WindowBlockGetterContents(previewData.getBlueprint(), BlueprintHandler.getInstance().getOptionalEntitiesForBlueprint(previewData)).openAsLayer();
+        new WindowBlockGetterContents(previewData.getBlueprint(), Minecraft.getInstance().level, BlueprintHandler.getInstance().getOptionalEntitiesForBlueprint(previewData)).openAsLayer();
     }
 
     /*

--- a/src/main/java/com/ldtteam/structurize/client/gui/AbstractBlueprintManipulationWindow.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/AbstractBlueprintManipulationWindow.java
@@ -15,6 +15,7 @@ import com.ldtteam.structurize.api.Utils;
 import com.ldtteam.structurize.api.constants.Constants;
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
 import com.ldtteam.structurize.blueprints.v1.BlueprintTagUtils;
+import com.ldtteam.structurize.client.BlueprintHandler;
 import com.ldtteam.structurize.client.ModKeyMappings;
 import com.ldtteam.structurize.network.messages.BuildToolPlacementMessage;
 import com.ldtteam.structurize.storage.ISurvivalBlueprintHandler;
@@ -113,6 +114,7 @@ public abstract class AbstractBlueprintManipulationWindow extends AbstractWindow
         registerButton(BUTTON_ROTATE_RIGHT, this::rotateRightClicked);
         registerButton(BUTTON_ROTATE_LEFT, this::rotateLeftClicked);
         registerButton(BUTTON_SETTINGS, this::settingsClicked);
+        registerButton(BUTTON_CONTENTS, this::openContents);
 
         settingsList = findPaneOfTypeByID("settinglist", ScrollingList.class);
         placementOptionsList = findPaneOfTypeByID("placement", ScrollingList.class);
@@ -259,6 +261,7 @@ public abstract class AbstractBlueprintManipulationWindow extends AbstractWindow
         {
             findPaneOfTypeByID("tip", Text.class).setVisible(false);
         }
+        findPaneByID(BUTTON_CONTENTS).setVisible(RenderingCache.getOrCreateBlueprintPreviewData(bluePrintId).getBlueprint() != null);
     }
 
     @Override
@@ -540,6 +543,12 @@ public abstract class AbstractBlueprintManipulationWindow extends AbstractWindow
     {
         RenderingCache.getOrCreateBlueprintPreviewData(bluePrintId).rotate(Rotation.COUNTERCLOCKWISE_90);
         updateRotationState();
+    }
+
+    private void openContents()
+    {
+        final BlueprintPreviewData previewData = RenderingCache.getOrCreateBlueprintPreviewData(bluePrintId);
+        new WindowBlockGetterContents(previewData.getBlueprint(), BlueprintHandler.getInstance().getOptionalEntitiesForBlueprint(previewData)).openAsLayer();
     }
 
     /*

--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowBlockGetterContents.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowBlockGetterContents.java
@@ -1,0 +1,117 @@
+package com.ldtteam.structurize.client.gui;
+
+import com.ldtteam.blockui.Pane;
+import com.ldtteam.blockui.controls.ItemIcon;
+import com.ldtteam.blockui.controls.Text;
+import com.ldtteam.blockui.views.BOWindow;
+import com.ldtteam.blockui.views.ScrollingList;
+import com.ldtteam.common.util.BlockToItemHelper;
+import com.ldtteam.structurize.api.ItemStackUtils;
+import com.ldtteam.structurize.api.ItemStorage;
+import com.ldtteam.structurize.api.constants.Constants;
+import com.ldtteam.structurize.blueprints.v1.Blueprint;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Computes as exact as possible contents of given AABB. This should be used as base for item related analysis
+ */
+public class WindowBlockGetterContents extends BOWindow
+{
+    public WindowBlockGetterContents(final Blueprint blockGetter, final Collection<Entity> boundedEntities)
+    {
+        this(blockGetter,
+            new BlockPos(blockGetter.getMinX(), blockGetter.getMinBuildHeight(), blockGetter.getMinZ()),
+            new BlockPos(blockGetter.getMaxX() - 1, blockGetter.getMaxBuildHeight() - 1, blockGetter.getMaxZ() - 1),
+            boundedEntities);
+    }
+
+    /**
+     * @param blockGetter     level
+     * @param start           inclusive from
+     * @param end             inclusive to
+     * @param boundedEntities entities bounded by [start, end] parameters
+     */
+    public WindowBlockGetterContents(final Blueprint blockGetter,
+        final BlockPos start,
+        final BlockPos end,
+        final Collection<Entity> boundedEntities)
+    {
+        super(Constants.resLocStruct("gui/windowcontents.xml"));
+
+        final Map<Item, ItemStorage> blocks = new HashMap<>();
+        final Map<Item, ItemStorage> blockItemHandlers = new HashMap<>();
+        final Map<Item, ItemStorage> entities = new HashMap<>();
+        final Map<Item, ItemStorage> entityItemHandlers = new HashMap<>();
+
+        for (final BlockPos pos : BlockPos.betweenClosed(start, end))
+        {
+            final BlockState blockState = blockGetter.getBlockState(pos);
+            final BlockEntity blockEntity = blockGetter.getBlockEntity(pos);
+
+            // blockstate
+            addAmountToMap(blocks, BlockToItemHelper.getItemStack(blockState, blockEntity, Minecraft.getInstance().player));
+
+            // blockentity content
+            ItemStackUtils.getItemHandlersFromProvider(blockEntity)
+                .forEach(i -> ItemStackUtils.deepExtractItemHandler(i, stack -> addAmountToMap(blockItemHandlers, stack)));
+        }
+
+        for (final Entity entity : boundedEntities)
+        {
+            addAmountToMap(entities, ItemStackUtils.getEntitySpawningItem(entity));
+            ItemStackUtils.getItemStacksOfEntity(entity).forEach(stack -> addAmountToMap(entityItemHandlers, stack));
+        }
+
+        final List<ItemStorage> blockList = new ArrayList<>(blocks.values());
+        final List<ItemStorage> blockItemHandlerList = new ArrayList<>(blockItemHandlers.values());
+        final List<ItemStorage> entityList = new ArrayList<>(entities.values());
+        final List<ItemStorage> entityItemHandlerList = new ArrayList<>(entityItemHandlers.values());
+
+        final Comparator<ItemStorage> alphabeticalOrder =
+            (i1, i2) -> i1.getItemStack().getHoverName().getString().compareTo(i2.getItemStack().getHoverName().getString());
+        blockList.sort(alphabeticalOrder);
+        blockItemHandlerList.sort(alphabeticalOrder);
+        entityList.sort(alphabeticalOrder);
+        entityItemHandlerList.sort(alphabeticalOrder);
+
+        findPaneOfTypeByID("blocks", ScrollingList.class).setDataProvider(blockList::size,
+            (idx, pane) -> updateItem(blockList.get(idx), pane));
+        findPaneOfTypeByID("block_item_handlers", ScrollingList.class).setDataProvider(blockItemHandlerList::size,
+            (idx, pane) -> updateItem(blockItemHandlerList.get(idx), pane));
+        findPaneOfTypeByID("entities", ScrollingList.class).setDataProvider(entityList::size,
+            (idx, pane) -> updateItem(entityList.get(idx), pane));
+        findPaneOfTypeByID("entity_item_handlers", ScrollingList.class).setDataProvider(entityItemHandlerList::size,
+            (idx, pane) -> updateItem(entityItemHandlerList.get(idx), pane));
+    }
+
+    private void addAmountToMap(final Map<Item, ItemStorage> itemSet, @Nullable final ItemStack blockAsItem)
+    {
+        if (blockAsItem != null)
+        {
+            itemSet.computeIfAbsent(blockAsItem.getItem(), i -> new ItemStorage(blockAsItem.copyWithCount(1), 0, true))
+                .addAmount(Math.max(1, blockAsItem.getCount()));
+        }
+    }
+
+    private void updateItem(final ItemStorage itemStorage, final Pane pane)
+    {
+        pane.findPaneOfTypeByID("icon", ItemIcon.class).setItem(itemStorage.getItemStack());
+        pane.findPaneOfTypeByID("registry_key", Text.class).setText(itemStorage.getItemStack().getHoverName());
+        pane.findPaneOfTypeByID("amount", Text.class).setText(Component.literal(Integer.toString(itemStorage.getAmount())));
+    }
+}

--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowBlockGetterContents.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowBlockGetterContents.java
@@ -25,7 +25,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
 /**
  * Computes as exact as possible contents of given AABB. This should be used as base for item related analysis

--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowScan.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowScan.java
@@ -478,7 +478,7 @@ public class WindowScan extends AbstractWindowSkeleton
                 boolean handled = false;
                 for (final IPlacementHandler handler : PlacementHandlers.handlers)
                 {
-                    if (handler.canHandle(world, BlockPos.ZERO, blockState))
+                    if (handler.canHandle(world, here, blockState))
                     {
                         final List<ItemStack> itemList = handler.getRequiredItems(world, here, blockState, tileEntity == null ? null : tileEntity.saveWithFullMetadata(world.registryAccess()), true);
                         for (final ItemStack stack : itemList)

--- a/src/main/java/com/ldtteam/structurize/commands/AbstractCommand.java
+++ b/src/main/java/com/ldtteam/structurize/commands/AbstractCommand.java
@@ -5,9 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import com.ldtteam.structurize.api.constants.Constants;
-import com.ldtteam.common.language.LanguageHandler;
 import com.mojang.brigadier.CommandDispatcher;
-import com.mojang.brigadier.LiteralMessage;
 import com.mojang.brigadier.arguments.ArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.builder.RequiredArgumentBuilder;
@@ -15,6 +13,7 @@ import com.mojang.brigadier.exceptions.CommandExceptionType;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands.CommandSelection;
+import net.minecraft.network.chat.Component;
 import net.minecraft.util.Tuple;
 
 /**
@@ -73,7 +72,7 @@ public abstract class AbstractCommand
      */
     public static void throwSyntaxException(final String key) throws CommandSyntaxException
     {
-        throw new CommandSyntaxException(new StructurizeCommandExceptionType(), new LiteralMessage(LanguageHandler.translateKey(key)));
+        throw new CommandSyntaxException(new StructurizeCommandExceptionType(), Component.translatable(key));
     }
 
     /**
@@ -84,8 +83,7 @@ public abstract class AbstractCommand
      */
     public static void throwSyntaxException(final String key, final Object... format) throws CommandSyntaxException
     {
-        throw new CommandSyntaxException(new StructurizeCommandExceptionType(),
-            new LiteralMessage(LanguageHandler.translateKeyWithFormat(key, format)));
+        throw new CommandSyntaxException(new StructurizeCommandExceptionType(), Component.translatable(key, format));
     }
 
     /**

--- a/src/main/java/com/ldtteam/structurize/items/ItemTagSubstitution.java
+++ b/src/main/java/com/ldtteam/structurize/items/ItemTagSubstitution.java
@@ -14,7 +14,6 @@ import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.HolderSet;
-import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;

--- a/src/main/java/com/ldtteam/structurize/items/ItemTagSubstitution.java
+++ b/src/main/java/com/ldtteam/structurize/items/ItemTagSubstitution.java
@@ -12,7 +12,6 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderSet;
-import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;

--- a/src/main/java/com/ldtteam/structurize/placement/StructurePlacer.java
+++ b/src/main/java/com/ldtteam/structurize/placement/StructurePlacer.java
@@ -282,7 +282,7 @@ public class StructurePlacer
                                 continue;
                             }
 
-                            List<ItemStack> requiredItems = ItemStackUtils.getListOfStackForEntity(entity, pos);
+                            List<ItemStack> requiredItems = ItemStackUtils.getListOfStackForEntity(entity);
                             if (!handler.isCreative())
                             {
                                 if (requiredItems == null)
@@ -465,7 +465,7 @@ public class StructurePlacer
                                 continue;
                             }
 
-                            List<ItemStack> requiredItems = ItemStackUtils.getListOfStackForEntity(entity, pos);
+                            List<ItemStack> requiredItems = ItemStackUtils.getListOfStackForEntity(entity);
                             if (!handler.isCreative())
                             {
                                 if (requiredItems == null)
@@ -620,7 +620,7 @@ public class StructurePlacer
                                 continue;
                             }
 
-                            requiredItems.addAll(ItemStackUtils.getListOfStackForEntity(entity, pos));
+                            requiredItems.addAll(ItemStackUtils.getListOfStackForEntity(entity));
                         }
                     }
                 }

--- a/src/main/java/com/ldtteam/structurize/placement/handlers/placement/PlacementHandlers.java
+++ b/src/main/java/com/ldtteam/structurize/placement/handlers/placement/PlacementHandlers.java
@@ -12,7 +12,6 @@ import com.ldtteam.structurize.util.BlockUtils;
 import com.ldtteam.structurize.api.RotationMirror;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.entity.Entity;
@@ -241,7 +240,7 @@ public final class PlacementHandlers
           @Nullable final CompoundTag tileEntityData,
           final boolean complete)
         {
-            final List<ItemStack> itemList = new ArrayList<>(getItemsFromTileEntity(tileEntityData, blockState, world.registryAccess()));
+            final List<ItemStack> itemList = new ArrayList<>(getItemsFromTileEntity(tileEntityData, blockState, world));
             itemList.add(BlockUtils.getItemStackFromBlockState(blockState));
             itemList.removeIf(ItemStackUtils::isEmpty);
 
@@ -742,7 +741,7 @@ public final class PlacementHandlers
           @Nullable final CompoundTag tileEntityData,
           final boolean complete)
         {
-            final List<ItemStack> itemList = new ArrayList<>(getItemsFromTileEntity(tileEntityData, blockState, world.registryAccess()));
+            final List<ItemStack> itemList = new ArrayList<>(getItemsFromTileEntity(tileEntityData, blockState, world));
             itemList.add(BlockUtils.getItemStackFromBlockState(blockState));
             itemList.removeIf(ItemStackUtils::isEmpty);
             return itemList;
@@ -777,7 +776,7 @@ public final class PlacementHandlers
             try
             {
                 // Try detecting inventory content.
-                ItemStackUtils.getItemStacksOfTileEntity(tileEntityData, blockState, world.registryAccess());
+                ItemStackUtils.getItemStacksOfTileEntity(tileEntityData, blockState, world);
             }
             catch (final Exception ex)
             {
@@ -803,7 +802,7 @@ public final class PlacementHandlers
         {
             final List<ItemStack> itemList = new ArrayList<>();
             itemList.add(BlockUtils.getItemStackFromBlockState(blockState));
-            itemList.addAll(getItemsFromTileEntity(tileEntityData, blockState, world.registryAccess()));
+            itemList.addAll(getItemsFromTileEntity(tileEntityData, blockState, world));
 
             itemList.removeIf(ItemStackUtils::isEmpty);
 
@@ -889,7 +888,7 @@ public final class PlacementHandlers
           @Nullable final CompoundTag tileEntityData,
           final boolean complete)
         {
-            final List<ItemStack> itemList = new ArrayList<>(getItemsFromTileEntity(tileEntityData, blockState, world.registryAccess()));
+            final List<ItemStack> itemList = new ArrayList<>(getItemsFromTileEntity(tileEntityData, blockState, world));
             itemList.add(BlockUtils.getItemStackFromBlockState(blockState));
             itemList.removeIf(ItemStackUtils::isEmpty);
             return itemList;
@@ -971,7 +970,7 @@ public final class PlacementHandlers
           @Nullable final CompoundTag tileEntityData,
           final boolean complete)
         {
-            final List<ItemStack> itemList = new ArrayList<>(getItemsFromTileEntity(tileEntityData, blockState, world.registryAccess()));
+            final List<ItemStack> itemList = new ArrayList<>(getItemsFromTileEntity(tileEntityData, blockState, world));
             itemList.add(BlockUtils.getItemStackFromBlockState(blockState));
             itemList.removeIf(ItemStackUtils::isEmpty);
             return itemList;
@@ -1079,7 +1078,7 @@ public final class PlacementHandlers
      * @param blockState     the block.
      * @return the required list.
      */
-    public static List<ItemStack> getItemsFromTileEntity(final CompoundTag tileEntityData, final BlockState blockState, final HolderLookup.Provider provider)
+    public static List<ItemStack> getItemsFromTileEntity(final CompoundTag tileEntityData, final BlockState blockState, final Level provider)
     {
         if (tileEntityData == null)
         {

--- a/src/main/java/com/ldtteam/structurize/util/BlockUtils.java
+++ b/src/main/java/com/ldtteam/structurize/util/BlockUtils.java
@@ -1,5 +1,6 @@
 package com.ldtteam.structurize.util;
 
+import com.ldtteam.common.util.BlockToItemHelper;
 import com.ldtteam.domumornamentum.client.model.data.MaterialTextureData;
 import com.ldtteam.domumornamentum.entity.block.MateriallyTexturedBlockEntity;
 import com.ldtteam.structurize.api.ItemStackUtils;
@@ -264,6 +265,7 @@ public final class BlockUtils
         return iBlockState.getBlock() == Blocks.WATER;
     }
 
+    @Deprecated(forRemoval = true, since = "1.21")
     private static Item getItem(final BlockState blockState)
     {
         final Block block = blockState.getBlock();
@@ -304,6 +306,7 @@ public final class BlockUtils
         }
     }
 
+    @Deprecated(forRemoval = true, since = "1.21")
     private static Item getItemFromBlock(final Block block)
     {
         return GameData.getBlockItemMap().get(block);
@@ -434,7 +437,9 @@ public final class BlockUtils
      *
      * @param blockState the block and state we are creating an ItemStack for.
      * @return ItemStack fromt the BlockState.
+     * @see BlockToItemHelper
      */
+    @Deprecated(forRemoval = true, since = "1.21")
     public static ItemStack getItemStackFromBlockState(final BlockState blockState)
     {
         if (blockState.getBlock() instanceof final LiquidBlock liquid)

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -21,3 +21,7 @@ public net.minecraft.world.level.levelgen.SurfaceRules$SurfaceRule
 
 # keybinds
 public net.minecraft.client.KeyMapping clickCount
+
+# itemHandler
+public net.minecraft.world.entity.decoration.GlowItemFrame getFrameItemStack()Lnet/minecraft/world/item/ItemStack;
+public net.minecraft.world.entity.decoration.ItemFrame getFrameItemStack()Lnet/minecraft/world/item/ItemStack;

--- a/src/main/resources/assets/structurize/gui/layoutmanipulation.xml
+++ b/src/main/resources/assets/structurize/gui/layoutmanipulation.xml
@@ -32,4 +32,5 @@
     <button id="cancel" source="structurize:textures/gui/buildtool/cancel.png" size="30" pos="90 213"/>
 
     <button id="settings" source="structurize:textures/gui/buildtool/settings.png" size="30" pos="0 213"/>
+    <button id="contents" source="structurize:textures/gui/buildtool/paste.png" size="32 32" pos="30 212" tooltip="$(com.ldtteam.structurize.gui.scantool.showres)" visible="false"/>
 </window>

--- a/src/main/resources/assets/structurize/gui/windowcontents.xml
+++ b/src/main/resources/assets/structurize/gui/windowcontents.xml
@@ -1,0 +1,37 @@
+<window xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/ldtteam/BlockUI/version/main/src/main/resources/assets/blockui/gui/block_ui.xsd"
+    size="630 480" pause="false" lightbox="true">
+
+    <text size="150 10" pos="0 0" text="$(structurize.gui.content.blocks)"/>
+    <list id="blocks" size="150 470" pos="0 10" childspacing="-1">
+        <box size="100% 20" linewidth="1">
+            <itemicon id="icon" size="16 16" pos="1 2"/>
+            <text id="registry_key" size="120 9" pos="19 1" wrap="true"/>
+            <text id="amount" size="120 9" pos="19 11"/>
+        </box>
+    </list>
+    <text size="150 10" pos="160 0" text="$(structurize.gui.content.blocks_content)"/>
+    <list id="block_item_handlers" size="150 470" pos="160 10" childspacing="-1">
+        <box size="100% 20" linewidth="1">
+            <itemicon id="icon" size="16 16" pos="1 2"/>
+            <text id="registry_key" size="120 9" pos="19 1" wrap="true"/>
+            <text id="amount" size="120 9" pos="19 11"/>
+        </box>
+    </list>
+    <text size="150 10" pos="320 0" text="$(structurize.gui.content.entities)"/>
+    <list id="entities" size="150 470" pos="320 10" childspacing="-1">
+        <box size="100% 20" linewidth="1">
+            <itemicon id="icon" size="16 16" pos="1 2"/>
+            <text id="registry_key" size="120 9" pos="19 1" wrap="true"/>
+            <text id="amount" size="120 9" pos="19 11"/>
+        </box>
+    </list>
+    <text size="150 10" pos="480 0" text="$(structurize.gui.content.entities_content)"/>
+    <list id="entity_item_handlers" size="150 470" pos="480 10" childspacing="-1">
+        <box size="100% 20" linewidth="1">
+            <itemicon id="icon" size="16 16" pos="1 2"/>
+            <text id="registry_key" size="120 9" pos="19 1" wrap="true"/>
+            <text id="amount" size="120 9" pos="19 11"/>
+        </box>
+    </list>
+</window>

--- a/src/main/resources/assets/structurize/lang/en_us.json
+++ b/src/main/resources/assets/structurize/lang/en_us.json
@@ -221,6 +221,9 @@
   "com.ldtteam.structurize.redo": "Redo %s",
   "structurize.gui.undoredo.redoop": "Redo",
   "structurize.gui.undoredo.undoop": "Undo",
-  "com.ldtteam.structurize.gui.scantool.remove_filtered": "Remove Filtered"
-
+  "com.ldtteam.structurize.gui.scantool.remove_filtered": "Remove Filtered",
+  "structurize.gui.content.blocks": "Blocks",
+  "structurize.gui.content.blocks_content": "Blocks internal content",
+  "structurize.gui.content.entities": "Entities",
+  "structurize.gui.content.entities_content": "Entities internal content"
 }

--- a/src/main/resources/assets/structurize/lang/en_us.json
+++ b/src/main/resources/assets/structurize/lang/en_us.json
@@ -223,7 +223,7 @@
   "structurize.gui.undoredo.undoop": "Undo",
   "com.ldtteam.structurize.gui.scantool.remove_filtered": "Remove Filtered",
   "structurize.gui.content.blocks": "Blocks",
-  "structurize.gui.content.blocks_content": "Blocks internal content",
+  "structurize.gui.content.blocks_content": "Block contents",
   "structurize.gui.content.entities": "Entities",
-  "structurize.gui.content.entities_content": "Entities internal content"
+  "structurize.gui.content.entities_content": "Entity contents"
 }


### PR DESCRIPTION
# Changes proposed in this pull request
- requires ldtteam/blockui#101
- reworks how we handle itemhandlers etc., should produce much more precise content handling, including nested inventories like shulkers
- added "show resources" for build tool, scan tool doesnt do content extraction, build tool runs same methods as structure placer, so technically builder should show exactly the same as build tool resources
- tested in single with blueprint shown on picture - all vanilla BEs with content, also tested with most entities

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please

![image](https://github.com/user-attachments/assets/cda14539-8948-4ca7-a1cc-716d1c4b06ed)
![image](https://github.com/user-attachments/assets/4be3d680-b691-438a-87d1-2570445ff9a6)
