### PR TITLE
save progress pos

### DIFF
--- a/src/main/java/com/ldtteam/structurize/placement/AbstractBlueprintIterator.java
+++ b/src/main/java/com/ldtteam/structurize/placement/AbstractBlueprintIterator.java
@@ -15,15 +15,20 @@ import java.util.function.Supplier;
  */
 public abstract class AbstractBlueprintIterator implements IBlueprintIterator
 {
-
     /**
      * The position we use as our uninitialized value.
      */
     public static final BlockPos NULL_POS = new BlockPos(-1, -1, -1);
+
     /**
      * The Structure position we are at. Defaulted to NULL_POS.
      */
     protected final BlockPos.MutableBlockPos progressPos = new BlockPos.MutableBlockPos(-1, -1, -1);
+
+    /**
+     * The previous position before the current progress position.
+     */
+    protected final BlockPos.MutableBlockPos prevProgressPos = new BlockPos.MutableBlockPos(-1, -1, -1);
 
     /**
      * The size of the structure.
@@ -118,6 +123,7 @@ public abstract class AbstractBlueprintIterator implements IBlueprintIterator
     @Override
     public void setProgressPos(final BlockPos localPosition)
     {
+        this.prevProgressPos.set(this.progressPos);
         if (localPosition.equals(NULL_POS))
         {
             this.progressPos.set(localPosition);
@@ -163,6 +169,7 @@ public abstract class AbstractBlueprintIterator implements IBlueprintIterator
     @Override
     public void reset()
     {
+        prevProgressPos.set(NULL_POS);
         progressPos.set(NULL_POS);
         includeEntities = false;
         isRemoving = false;
@@ -178,6 +185,12 @@ public abstract class AbstractBlueprintIterator implements IBlueprintIterator
     public BlockPos getProgressPos()
     {
         return progressPos.immutable();
+    }
+
+    @Override
+    public BlockPos getPrevProgressPos()
+    {
+        return prevProgressPos.immutable();
     }
 
     protected IStructureHandler getStructureHandler()

--- a/src/main/java/com/ldtteam/structurize/placement/BlueprintIteratorDefault.java
+++ b/src/main/java/com/ldtteam/structurize/placement/BlueprintIteratorDefault.java
@@ -31,6 +31,7 @@ public class BlueprintIteratorDefault extends AbstractBlueprintIterator
 
     private Result iterate(boolean up)
     {
+        this.prevProgressPos.set(this.progressPos);
         if (this.progressPos.equals(NULL_POS))
         {
             this.progressPos.set(-1, up ? 0 : this.size.getY() -1, 0);

--- a/src/main/java/com/ldtteam/structurize/placement/BlueprintIteratorHilbert.java
+++ b/src/main/java/com/ldtteam/structurize/placement/BlueprintIteratorHilbert.java
@@ -31,6 +31,7 @@ public class BlueprintIteratorHilbert extends AbstractBlueprintIterator
     @Override
     public Result increment()
     {
+        this.prevProgressPos.set(this.progressPos);
         if (this.progressPos.equals(NULL_POS))
         {
             this.index = 0;
@@ -44,6 +45,7 @@ public class BlueprintIteratorHilbert extends AbstractBlueprintIterator
     @Override
     public Result decrement()
     {
+        this.prevProgressPos.set(this.progressPos);
         if (this.progressPos.equals(NULL_POS))
         {
             this.index = (this.size.getY() & 1) == 0 ? this.positions.size() - 1 : 0;

--- a/src/main/java/com/ldtteam/structurize/placement/BlueprintIteratorInwardCircle.java
+++ b/src/main/java/com/ldtteam/structurize/placement/BlueprintIteratorInwardCircle.java
@@ -32,6 +32,7 @@ public class BlueprintIteratorInwardCircle extends AbstractBlueprintIterator
      */
     public Result iterate(final boolean up)
     {
+        this.prevProgressPos.set(this.progressPos);
         if (this.progressPos.equals(NULL_POS))
         {
             this.progressPos.set(-1, up ? 0 : this.size.getY() - 1, 0);

--- a/src/main/java/com/ldtteam/structurize/placement/BlueprintIteratorInwardCircleHeight.java
+++ b/src/main/java/com/ldtteam/structurize/placement/BlueprintIteratorInwardCircleHeight.java
@@ -22,6 +22,7 @@ public class BlueprintIteratorInwardCircleHeight extends AbstractBlueprintIterat
     @Override
     public Result increment()
     {
+        this.prevProgressPos.set(this.progressPos);
         if (this.progressPos.equals(NULL_POS))
         {
             this.progressPos.set(0, 0, 0);
@@ -42,6 +43,7 @@ public class BlueprintIteratorInwardCircleHeight extends AbstractBlueprintIterat
     @Override
     public Result decrement()
     {
+        this.prevProgressPos.set(this.progressPos);
         if (this.progressPos.equals(NULL_POS))
         {
             this.progressPos.set(0, topRightCorner.getY(), 0);

--- a/src/main/java/com/ldtteam/structurize/placement/BlueprintIteratorRandom.java
+++ b/src/main/java/com/ldtteam/structurize/placement/BlueprintIteratorRandom.java
@@ -43,6 +43,7 @@ public class BlueprintIteratorRandom extends AbstractBlueprintIterator
      */
     public Result increment()
     {
+        this.prevProgressPos.set(this.progressPos);
         if (this.progressPos.equals(NULL_POS))
         {
             this.progressPos.set(this.positions.get(0).getX(), 0, this.positions.get(0).getZ());
@@ -75,6 +76,7 @@ public class BlueprintIteratorRandom extends AbstractBlueprintIterator
      */
     public Result decrement()
     {
+        this.prevProgressPos.set(this.progressPos);
         if (this.progressPos.equals(NULL_POS))
         {
             this.progressPos.set(this.positions.get(0).getX(), this.size.getY() - 1, this.positions.get(0).getZ());

--- a/src/main/java/com/ldtteam/structurize/placement/IBlueprintIterator.java
+++ b/src/main/java/com/ldtteam/structurize/placement/IBlueprintIterator.java
@@ -84,6 +84,12 @@ public interface IBlueprintIterator
     BlockPos getProgressPos();
 
     /**
+     * Get the last position before the progress pos of the iterator.
+     * @return the prev progress pos.
+     */
+    BlockPos getPrevProgressPos();
+
+    /**
      * Get the size of the blueprint which is iterated over
      * @return the size
      */

--- a/src/main/java/com/ldtteam/structurize/placement/StructurePlacer.java
+++ b/src/main/java/com/ldtteam/structurize/placement/StructurePlacer.java
@@ -120,6 +120,7 @@ public class StructurePlacer
         {
             final BlockPos localPos = iterator.getProgressPos();
             final BlockPos worldPos = handler.getProgressPosInWorld(localPos);
+            lastPos = iterator.getPrevProgressPos();
 
             if (count >= handler.getStepsPerCall())
             {
@@ -129,7 +130,6 @@ public class StructurePlacer
             final BlockState localState = handler.getBluePrint().getBlockState(localPos);
             if (localState == null || world.isOutsideBuildHeight(worldPos))
             {
-                lastPos = localPos;
                 iterationResult = iterateFunction.get();
                 continue;
             }


### PR DESCRIPTION
Closes #
Closes #

# Changes proposed in this pull request
- Save the last iterator pos before setting a new one as "prev progress pos". Only reset to this point when restarting (saves going back too far). 
-

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please