### PR TITLE
Add config option to disable hotbar scroll

### DIFF
--- a/src/main/java/com/ldtteam/structurize/config/ClientConfiguration.java
+++ b/src/main/java/com/ldtteam/structurize/config/ClientConfiguration.java
@@ -25,6 +25,7 @@ public class ClientConfiguration extends AbstractConfiguration
     public final BooleanValue displayShared;
     public final IntValue rendererLightLevel;
     public final DoubleValue rendererTransparency;
+    public final BooleanValue scanToolScrolling;
 
     /**
      * Builds client configuration.
@@ -58,7 +59,12 @@ public class ClientConfiguration extends AbstractConfiguration
             }
         });
 
-        finishCategory(builder);
+        finishCategory(builder);    // blueprint.renderer
+        finishCategory(builder);    // blueprint
+
+        createCategory(builder, "gameplay");
+        scanToolScrolling = defineBoolean(builder, "scan_tool_scrolling", true);
+        finishCategory(builder);    // gameplay
     }
 
     /**

--- a/src/main/java/com/ldtteam/structurize/items/ItemScanTool.java
+++ b/src/main/java/com/ldtteam/structurize/items/ItemScanTool.java
@@ -281,7 +281,7 @@ public class ItemScanTool extends AbstractItemWithPosSelector implements IScroll
         {
             // treat pick in air like mouse scrolling (just in case someone doesn't have a wheel)
             final double delta = player.isShiftKeyDown() ? -1 : 1;
-            return onMouseScroll(player, stack, delta, ctrlKey);
+            return switchSlot(player, stack, delta < 0 ? ScanToolData::prevSlot : ScanToolData::nextSlot);
         }
 
         if (player.level().getBlockEntity(pos) instanceof CommandBlockEntity command)
@@ -300,26 +300,31 @@ public class ItemScanTool extends AbstractItemWithPosSelector implements IScroll
                                            final double delta,
                                            final boolean ctrlKey)
     {
+        if (!player.level().isClientSide() || Structurize.getConfig().getClient().scanToolScrolling.get())
+        {
+            return switchSlot(player, stack, delta < 0 ? ScanToolData::prevSlot : ScanToolData::nextSlot);
+        }
+
+        return InteractionResult.PASS;
+    }
+
+    @NotNull
+    private InteractionResult switchSlot(@NotNull final Player player,
+                                         @NotNull final ItemStack stack,
+                                         @NotNull final Consumer<ScanToolData> action)
+    {
         if (player.level().isClientSide())
         {
             return InteractionResult.SUCCESS;
         }
 
-        switchSlot((ServerPlayer) player, stack, delta < 0 ? ScanToolData::prevSlot : ScanToolData::nextSlot);
-
-        return InteractionResult.SUCCESS;
-    }
-
-    private void switchSlot(@NotNull final ServerPlayer player,
-                            @NotNull final ItemStack stack,
-                            @NotNull final Consumer<ScanToolData> action)
-    {
         final ScanToolData data = new ScanToolData(stack.getOrCreateTag());
         saveSlot(data, stack, player);
         action.accept(data);
         final ScanToolData.Slot slot = loadSlot(data, stack);
 
-        Network.getNetwork().sendToPlayer(new ShowScanMessage(slot.getBox()), player);
+        Network.getNetwork().sendToPlayer(new ShowScanMessage(slot.getBox()), (ServerPlayer) player);
+        return InteractionResult.SUCCESS;
     }
 
     private void saveSlot(@NotNull final ScanToolData data,

--- a/src/main/resources/assets/structurize/lang/en_us.json
+++ b/src/main/resources/assets/structurize/lang/en_us.json
@@ -132,6 +132,8 @@
   "structurize.config.maxoperationspertick.comment": "Max world operations per tick (max blocks to place, remove, or replace).",
   "structurize.config.render_placeholders_nice": "Render placeholders as target blocks",
   "structurize.config.render_placeholders_nice.comment": "If disabled show placeholders as normal blocks, if enabled render: any (light) -> nothing, fluid (blue) -> dimension default fluid, solid (brown) -> worldgen block, tag (transparent) -> content block. Fluid and solid only work in singleplayer/for LAN owner, else it's just best guess. Currently without auto-updating",
+  "structurize.config.scan_tool_scrolling": "Scan Tool Scrolling",
+  "structurize.config.scan_tool_scrolling.comment": "Sneak+scroll on the hotbar switches scan tool slots",
   "structurize.config.see_shared_previews": "See previews from others",
   "structurize.config.see_shared_previews.comment": "Once enabled you will see previews from other players within sensible distance",
   "structurize.config.share_previews": "Share previews to others",


### PR DESCRIPTION
Closes [discord request](https://discord.com/channels/472875599422291968/1091653133064749197/1357676223148327122)

# Changes proposed in this pull request
- Adds client config to allow disabling sneak+scroll on scan tool hotbar

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please (should port)