### PR TITLE
fix 732 & 731

### DIFF
--- a/src/main/java/com/ldtteam/structurize/network/messages/SaveScanMessage.java
+++ b/src/main/java/com/ldtteam/structurize/network/messages/SaveScanMessage.java
@@ -41,7 +41,7 @@ public class SaveScanMessage extends AbstractClientPlayMessage
         String name = null;
         try (ByteBufInputStream stream = new ByteBufInputStream(buffer))
         {
-            final CompoundTag wrapperCompound = NbtIo.readCompressed(stream, NbtAccounter.unlimitedHeap());
+            final CompoundTag wrapperCompound = NbtIo.read(stream, NbtAccounter.unlimitedHeap());
             tag = wrapperCompound.getCompound(TAG_SCHEMATIC);
             name = wrapperCompound.getString(TAG_MILLIS);
         }
@@ -80,7 +80,7 @@ public class SaveScanMessage extends AbstractClientPlayMessage
         final FriendlyByteBuf buffer = new FriendlyByteBuf(buf);
         try (ByteBufOutputStream stream = new ByteBufOutputStream(buffer))
         {
-            NbtIo.writeCompressed(wrapperCompound, stream);
+            NbtIo.write(wrapperCompound, stream);
         }
         catch (final IOException e)
         {


### PR DESCRIPTION
Closes #731
Closes #732

# Changes proposed in this pull request
- Compression of nbt read/write seems to leave leftover data in edge cases. Non compressed works fine. Network compresses later differently anyway.
-

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please