### PR TITLE
Fix incorrect pack disabling

### DIFF
--- a/src/main/java/com/ldtteam/structurize/network/messages/NotifyClientAboutStructurePacksMessage.java
+++ b/src/main/java/com/ldtteam/structurize/network/messages/NotifyClientAboutStructurePacksMessage.java
@@ -9,6 +9,7 @@ import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.world.entity.player.Player;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -42,15 +43,12 @@ public class NotifyClientAboutStructurePacksMessage extends AbstractClientPlayMe
      * Notify the client about the server structurepacks.
      * @param clientStructurePacks the list of packs.
      */
-    public NotifyClientAboutStructurePacksMessage(final Map<String, StructurePackMeta> clientStructurePacks)
+    public NotifyClientAboutStructurePacksMessage(final Collection<StructurePackMeta> clientStructurePacks)
     {
         super(TYPE);
-        for (final StructurePackMeta pack : clientStructurePacks.values())
+        for (final StructurePackMeta pack : clientStructurePacks)
         {
-            if (!pack.isImmutable())
-            {
-                this.serverStructurePacks.put(pack.getName(), pack.getVersion());
-            }
+            this.serverStructurePacks.put(pack.getName(), pack.getVersion());
         }
     }
 

--- a/src/main/java/com/ldtteam/structurize/network/messages/NotifyServerAboutStructurePacksMessage.java
+++ b/src/main/java/com/ldtteam/structurize/network/messages/NotifyServerAboutStructurePacksMessage.java
@@ -48,10 +48,7 @@ public class NotifyServerAboutStructurePacksMessage extends AbstractServerPlayMe
         super(TYPE);
         for (final StructurePackMeta pack : clientStructurePacks)
         {
-            if (!pack.isImmutable())
-            {
-                this.clientStructurePacks.put(pack.getName(), pack.getVersion());
-            }
+            this.clientStructurePacks.put(pack.getName(), pack.getVersion());
         }
     }
 

--- a/src/main/java/com/ldtteam/structurize/storage/ClientStructurePackLoader.java
+++ b/src/main/java/com/ldtteam/structurize/storage/ClientStructurePackLoader.java
@@ -175,8 +175,6 @@ public class ClientStructurePackLoader
 
         if (serverStructurePacks.isEmpty())
         {
-            checkPackDifferences(serverStructurePacks);
-
             // Most likely single player. Skip.
             loadingState = ClientLoadingState.FINISHED_SYNCING;
             StructurePacks.setFinishedLoading();
@@ -218,22 +216,33 @@ public class ClientStructurePackLoader
         boolean needsChanges = false;
         for (final StructurePackMeta pack : StructurePacks.getPackMetas())
         {
+            // Assume the pack is fine by default
             pack.setDisabled(false);
+
+            // Validate the version of the server pack
             final double version = serverStructurePacks.getOrDefault(pack.getName(), -1.0);
+
+            // If the server pack version is -1 it means the server doesn't have this pack
             if (version == -1)
             {
                 if (!Structurize.getConfig().getServer().allowPlayerSchematics.get())
                 {
-                    // Don't have this pack on the server, disable.
                     pack.setDisabled(true);
                 }
             }
+            // Version on the client is different
             else if (version != pack.getVersion())
             {
-                // Version on the client is outdated. Set that we got pending changes.
-                pack.setDisabled(true);
-                if (!pack.isImmutable())
+                // If the pack is immutable, meaning from a jar, we cannot update it, so it becomes disabled
+                if (pack.isImmutable())
                 {
+                    pack.setDisabled(true);
+                }
+                // If the pack is mutable, we remove the local copy and tell the server we want to synchronize this pack anew
+                // On the next iteration, the client should tell the server it's now missing this pack, which should initiate a copy from the server
+                else
+                {
+                    StructurePacks.removePack(pack.getName());
                     needsChanges = true;
                 }
             }

--- a/src/main/java/com/ldtteam/structurize/storage/ServerStructurePackLoader.java
+++ b/src/main/java/com/ldtteam/structurize/storage/ServerStructurePackLoader.java
@@ -10,7 +10,6 @@ import io.netty.buffer.Unpooled;
 import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.ModList;
-import net.neoforged.neoforge.event.tick.LevelTickEvent;
 import net.neoforged.neoforge.event.tick.ServerTickEvent;
 import net.neoforged.neoforgespi.language.IModInfo;
 import java.io.File;
@@ -161,7 +160,7 @@ public class ServerStructurePackLoader
     {
         if (loadingState == ServerLoadingState.UNINITIALIZED)
         {
-            new NotifyClientAboutStructurePacksMessage(Collections.emptyMap()).sendToPlayer(player);
+            new NotifyClientAboutStructurePacksMessage(List.of()).sendToPlayer(player);
             // Noop Single Player, Nothing to do here.
             return;
         }
@@ -207,32 +206,22 @@ public class ServerStructurePackLoader
 
     /**
      * Handle the client update for a given player and their packs.
-     * @param clientStructurePacks the client structure packs.
      * @param player the player.
      */
     private static void handleClientUpdate(final Map<String, Double> clientStructurePacks, final ServerPlayer player)
     {
+        new NotifyClientAboutStructurePacksMessage(StructurePacks.getPackMetas()).sendToPlayer(player);
+
         final UUID uuid = player.getUUID();
         final Map<String, StructurePackMeta> missingPacks = new HashMap<>();
-        final Map<String, StructurePackMeta> packsToSync = new HashMap<>();
 
         for (final StructurePackMeta pack : StructurePacks.getPackMetas())
         {
-            if (!pack.isImmutable())
+            if (!pack.isImmutable() && clientStructurePacks.getOrDefault(pack.getName(), -1.0) != pack.getVersion())
             {
-                if (clientStructurePacks.getOrDefault(pack.getName(), -1.0) != pack.getVersion())
-                {
-                    missingPacks.put(pack.getName(), pack);
-                }
-                else
-                {
-                    packsToSync.put(pack.getName(), pack);
-                }
+                missingPacks.put(pack.getName(), pack);
             }
         }
-
-        packsToSync.putAll(missingPacks);
-        new NotifyClientAboutStructurePacksMessage(packsToSync).sendToPlayer(player);
 
         IOPool.execute(() -> {
             int index = 1;


### PR DESCRIPTION
Closes [discord report](https://discord.com/channels/139070364159311872/1125094832143077456/1419745392316121199) (all minecolonies pack are getting disabled)

# Changes proposed in this pull request
- The synchronisations were only doing partial synchronisations of things it thought it had to sync, this was causing some packs to be incorrectly marked as disabled
- Synchronisation now syncs the full pack list in all cases, leaving the full comparison up to the server and client
- The server no longer determines to only sync missing packs back to the client, instead it sends everything, if something is missing, it'll still send the server->client pack transfer message out
- Fixed an issue where local mutable incorrectly versioned packs wouldn't get removed, and thus wouldn't be overwritten with a new version upon sync, these are now correctly removed instead of getting disabled (only immutable packs will be disabled, i.e. if a client brings a different version of Minecolonies somehow, and has a pack with a different verrsion)

## Testing
- [X] Yes I tested this before submitting it.
- [X] I also did a multiplayer test.

Review please