### PR TITLE
Fix 2 issues

### DIFF
--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowExtendedBuildTool.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowExtendedBuildTool.java
@@ -217,7 +217,7 @@ public final class WindowExtendedBuildTool extends AbstractBlueprintManipulation
             return;
         }
 
-        if (StringUtils.isBlank(currentStructurePack) && !currentStructurePack.equals(selectedPack.getName()))
+        if (!StringUtils.isBlank(currentStructurePack) && !currentStructurePack.equals(selectedPack.getName()))
         {
             depth = "";
             currentBluePrintMappingAtDepthCache.clear();

--- a/src/main/java/com/ldtteam/structurize/storage/ServerStructurePackLoader.java
+++ b/src/main/java/com/ldtteam/structurize/storage/ServerStructurePackLoader.java
@@ -12,6 +12,8 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.ModList;
 import net.neoforged.neoforge.event.tick.ServerTickEvent;
 import net.neoforged.neoforgespi.language.IModInfo;
+import org.jetbrains.annotations.NotNull;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.*;
@@ -251,18 +253,20 @@ public class ServerStructurePackLoader
             Files.walkFileTree(sourcePath, new SimpleFileVisitor<>()
             {
                 @Override
-                public FileVisitResult preVisitDirectory(final Path dir, final BasicFileAttributes attrs) throws IOException
+                @NotNull
+                public FileVisitResult preVisitDirectory(@NotNull final Path dir, @NotNull final BasicFileAttributes attrs) throws IOException
                 {
                     if (!sourcePath.equals(dir))
                     {
-                        zos.putNextEntry(new ZipEntry(sourcePath.relativize(dir) + File.separator));
+                        zos.putNextEntry(new ZipEntry(sourcePath.relativize(dir) + "/"));
                         zos.closeEntry();
                     }
                     return FileVisitResult.CONTINUE;
                 }
 
                 @Override
-                public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException
+                @NotNull
+                public FileVisitResult visitFile(@NotNull final Path file, @NotNull final BasicFileAttributes attrs) throws IOException
                 {
                     zos.putNextEntry(new ZipEntry(sourcePath.relativize(file).toString()));
                     Files.copy(file, zos);
@@ -273,7 +277,7 @@ public class ServerStructurePackLoader
         }
         catch (IOException e)
         {
-            Log.getLogger().warn("Unable to ZIP up: " + sourcePath.toString());
+            Log.getLogger().warn("Unable to ZIP up: {}", sourcePath);
             return null;
         }
         return buffer;


### PR DESCRIPTION
- Closes ldtteam/minecolonies#11216

# Changes proposed in this pull request
- Fixed an incorrect migration of the `currentStructurePack`, condition should've been inverted
- Fixed an issue with pack transfer when the server is running on Windows, ZipEntry only considers an entry a directory if it ends in "/" explicitly, Windows using "\" breaks this behaviour.

## Testing
- [X] Yes I tested this before submitting it.
- [X] I also did a multiplayer test.

Review please