### PR TITLE
Fix select res missing player items

### DIFF
--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowReplaceBlock.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowReplaceBlock.java
@@ -46,7 +46,7 @@ public class WindowReplaceBlock extends WindowSelectRes
         super(origin,
             Component.translatable("com.ldtteam.structurize.gui.replaceblock.info"),
             toReplace.itemStorage.getItemStack(),
-            ItemUtil.getAllItems(),
+            ItemUtil.getAllItemsInlcudingInventory(),
             ((stack, integer) -> {}),
             true,
             Component.translatable("com.ldtteam.structurize.gui.scan.replace.pct"));

--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowSelectRes.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowSelectRes.java
@@ -324,11 +324,15 @@ public class WindowSelectRes extends AbstractWindowSkeleton
 
         if (filter.isEmpty())
         {
-            displayedItems.sort(Comparator.comparing(s1 -> s1.getHoverName().getString()));
+            displayedItems.sort(Comparator.comparing(s -> mc.player.getInventory().contains((ItemStack) s))
+                .reversed()
+                .thenComparing((s1 -> ((ItemStack) s1).getHoverName().getString())));
         }
         else
         {
-            displayedItems.sort(Comparator.comparingInt(s1 -> StringUtils.getLevenshteinDistance(s1.getHoverName().getString(), filter)));
+            displayedItems.sort(Comparator.comparing(s -> mc.player.getInventory().contains((ItemStack) s))
+                .reversed()
+                .thenComparingInt(s1 -> StringUtils.getLevenshteinDistance(((ItemStack) s1).getHoverName().getString(), filter)));
         }
         this.updateResourceList();
     }

--- a/src/main/java/com/ldtteam/structurize/client/gui/WindowShapeTool.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/WindowShapeTool.java
@@ -262,7 +262,13 @@ public class WindowShapeTool extends AbstractBlueprintManipulationWindow
      */
     private void pickMainBlock()
     {
-        new WindowSelectRes(this, Component.literal("Select the main block"), mainBlock, ItemUtil.getAllItems(), (s, c) -> updateBlock(s, true), false, null).open();
+        new WindowSelectRes(this,
+            Component.literal("Select the main block"),
+            mainBlock,
+            ItemUtil.getAllItemsInlcudingInventory(),
+            (s, c) -> updateBlock(s, true),
+            false,
+            null).open();
     }
 
     /**
@@ -270,7 +276,13 @@ public class WindowShapeTool extends AbstractBlueprintManipulationWindow
      */
     private void pickFillBlock()
     {
-        new WindowSelectRes(this, Component.literal("Select the main block"), secondaryBlock, ItemUtil.getAllItems(), (s, c) -> updateBlock(s, false), false, null).open();
+        new WindowSelectRes(this,
+            Component.literal("Select the main block"),
+            secondaryBlock,
+            ItemUtil.getAllItemsInlcudingInventory(),
+            (s, c) -> updateBlock(s, false),
+            false,
+            null).open();
     }
 
     private void adjust(final TextField input, final int value)

--- a/src/main/java/com/ldtteam/structurize/client/gui/util/ItemUtil.java
+++ b/src/main/java/com/ldtteam/structurize/client/gui/util/ItemUtil.java
@@ -1,19 +1,19 @@
 package com.ldtteam.structurize.client.gui.util;
 
 import com.google.common.collect.ImmutableList;
-import net.minecraft.world.item.AirItem;
-import net.minecraft.world.item.BlockItem;
-import net.minecraft.world.item.BucketItem;
-import net.minecraft.world.item.ItemStack;
+import com.ldtteam.structurize.api.util.ItemStorage;
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.item.*;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraftforge.registries.ForgeRegistries;
 
-import java.util.List;
-import java.util.Spliterator;
-import java.util.Spliterators;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+/**
+ * Client-side Item utility class
+ */
 public class ItemUtil
 {
     /**
@@ -28,5 +28,43 @@ public class ItemUtil
                 && ((BucketItem) item).getFluid() != Fluids.EMPTY))
             .map(ItemStack::new)
             .collect(Collectors.toList()));
+    }
+
+    /**
+     * Creates a list of all items that can be picked inlcuding player items
+     * Client-side
+     *
+     * @return
+     */
+    public static List<ItemStack> getAllItemsInlcudingInventory()
+    {
+        final Set<ItemStorage> items = new HashSet<>();
+        for (final Item item : ForgeRegistries.ITEMS)
+        {
+            if (item instanceof AirItem || item instanceof BlockItem || (item instanceof BucketItem
+                && ((BucketItem) item).getFluid() != Fluids.EMPTY))
+            {
+                items.add(new ItemStorage(new ItemStack(item)));
+            }
+        }
+
+        for (final ItemStack stack : Minecraft.getInstance().player.getInventory().items)
+        {
+            final Item item = stack.getItem();
+            if (item instanceof AirItem || item instanceof BlockItem || (item instanceof BucketItem
+                && ((BucketItem) item).getFluid() != Fluids.EMPTY))
+            {
+                items.add(new ItemStorage(stack.copy()));
+            }
+        }
+
+        final List<ItemStack> stackList = new ArrayList<>(items.size());
+
+        for (final ItemStorage storage : items)
+        {
+            stackList.add(storage.getItemStack());
+        }
+
+        return stackList;
     }
 }


### PR DESCRIPTION
Closes #809
Closes #

# Changes proposed in this pull request
- Fix player inventory items not available for picking replacement blocks in the shape or scan tool windows
- Player inventory items are now sorted ontop of the resource list

## Testing
- [ x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please