### PR TITLE
Rotation Crash on TagSubstitutionBlock

### DIFF
--- a/src/main/java/com/ldtteam/structurize/component/CapturedBlock.java
+++ b/src/main/java/com/ldtteam/structurize/component/CapturedBlock.java
@@ -67,21 +67,39 @@ public record CapturedBlock(BlockState blockState, Optional<CompoundTag> seriali
      */
     public CapturedBlock applyRotationMirror(final RotationMirror rotationMirror, final Level level)
     {
+        final BlockState rotatedState = rotationMirror.applyToBlockState(blockState);
+
+        // No BE data: just rotate the state.
         if (serializedBE.isEmpty())
         {
-            return new CapturedBlock(rotationMirror.applyToBlockState(blockState), serializedBE, itemStack);
+            return new CapturedBlock(rotatedState, serializedBE, itemStack);
         }
 
+        // If the rotated state cannot host a BE, drop any BE tag (prevents renderer/loader issues).
+        if (!rotatedState.hasBlockEntity())
+        {
+            return new CapturedBlock(rotatedState, Optional.empty(), itemStack);
+        }
+
+        // Rotate/migrate the BE tag using the Blueprint rotation logic
         final Blueprint blueprint = new Blueprint((short) 1, (short) 1, (short) 1, level.registryAccess());
-        blueprint.addBlockState(BlockPos.ZERO, blockState);
+        blueprint.addBlockState(BlockPos.ZERO, rotatedState);
         blueprint.getTileEntities()[0][0][0] = serializedBE.get();
         blueprint.setCachePrimaryOffset(BlockPos.ZERO);
         blueprint.setRotationMirrorRelative(rotationMirror, level);
 
-        return new CapturedBlock(blueprint.getPalette()[blueprint.getPalleteSize()],
-            Optional.of(blueprint.getTileEntities()[0][0][0]),
-            itemStack);
+        final CompoundTag rotatedTag = blueprint.getTileEntities()[0][0][0];
+        Optional<CompoundTag> beTag = Optional.ofNullable(rotatedTag);
+
+        // Drop invalid/empty BE tags.
+        if (beTag.isEmpty() || beTag.get().isEmpty() || !beTag.get().contains("id"))
+        {
+            beTag = Optional.empty();
+        }
+
+        return new CapturedBlock(rotatedState, beTag, itemStack);
     }
+
 
     public boolean hasBlockEntity()
     {

--- a/src/main/java/com/ldtteam/structurize/component/CapturedBlock.java
+++ b/src/main/java/com/ldtteam/structurize/component/CapturedBlock.java
@@ -1,5 +1,6 @@
 package com.ldtteam.structurize.component;
 
+import com.ldtteam.structurize.api.Log;
 import com.ldtteam.structurize.api.RotationMirror;
 import com.ldtteam.structurize.blueprints.v1.Blueprint;
 import com.mojang.serialization.Codec;
@@ -75,9 +76,10 @@ public record CapturedBlock(BlockState blockState, Optional<CompoundTag> seriali
             return new CapturedBlock(rotatedState, serializedBE, itemStack);
         }
 
-        // If the rotated state cannot host a BE, drop any BE tag (prevents renderer/loader issues).
+        // If the rotated state does not host a BE, drop any BE tag (prevents renderer/loader issues).
         if (!rotatedState.hasBlockEntity())
         {
+             Log.getLogger().warn("Block {} is not empty, but has no block entity.", rotatedState);
             return new CapturedBlock(rotatedState, Optional.empty(), itemStack);
         }
 


### PR DESCRIPTION
Closes #813

# Changes proposed in this pull request
- Changed the logic around the rotation of the TagSubstitutionBlock to avoid the crash reported in #813 

## Testing
- [X] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

I was able to reproduce the crash and confirm that after the fix it was eliminated.
I did a number of other tests using the TagSubstitutionBlock.  I did note that if the TSB is put on a chest that the rotation of the chest was NOT correctly reflected (the position was, but not the facing).  I did confirm that contents were persisted as well.

After a number of attempts to explore fixes, I decided to submit this small improvement (no crash) despite the lack of proper chest orientation post-rotation.

Review please