### PR TITLE
Using ChunkStatus.SURFACE insteadof null

### DIFF
--- a/src/main/java/com/ldtteam/structurize/util/BlockUtils.java
+++ b/src/main/java/com/ldtteam/structurize/util/BlockUtils.java
@@ -739,7 +739,7 @@ public final class BlockUtils
     {
         private OurWorldGenRegion(ServerLevel p_143484_, List<ChunkAccess> p_143485_)
         {
-            super(p_143484_, p_143485_, null, -1);
+            super(p_143484_, p_143485_, ChunkStatus.EMPTY, -1);
         }
 
         @Override

--- a/src/main/java/com/ldtteam/structurize/util/BlockUtils.java
+++ b/src/main/java/com/ldtteam/structurize/util/BlockUtils.java
@@ -739,7 +739,7 @@ public final class BlockUtils
     {
         private OurWorldGenRegion(ServerLevel p_143484_, List<ChunkAccess> p_143485_)
         {
-            super(p_143484_, p_143485_, ChunkStatus.EMPTY, -1);
+            super(p_143484_, p_143485_, ChunkStatus.SURFACE, -1);
         }
 
         @Override


### PR DESCRIPTION
Closes #
Closes #

# Changes proposed in this pull request
- RelativityMC/C2ME-fabric#508
-

## Testing
- [ ] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Crashed code.
https://github.com/RelativityMC/C2ME-fabric/blob/4e4b37e5848f70a4b53776d59263f831c6a7d113/c2me-threading-worldgen/src/main/java/com/ishland/c2me/threading/worldgen/mixin/MixinChunkRegion.java#L41-L44
<img width="1151" height="561" alt="image" src="https://github.com/user-attachments/assets/c3742d56-d198-4a60-84b7-6ad88be8cd3d" />

The parameter what type is `ChunkStatus` is not marked as nullable.
I think using `ChunkStatus.EMPTY` is better than `null` even if it is no used anywhere in vanilla.
<img width="1020" height="565" alt="image" src="https://github.com/user-attachments/assets/bd5a6f0e-1064-4107-8611-d88d3bebc725" />


Review please