### PR TITLE
Allow support blocks on tan placeholder faces

### DIFF
--- a/src/main/java/com/ldtteam/structurize/blocks/schematic/BlockSubstitution.java
+++ b/src/main/java/com/ldtteam/structurize/blocks/schematic/BlockSubstitution.java
@@ -58,4 +58,11 @@ public class BlockSubstitution extends Block
 
         return super.getCollisionShape(state,blockGetter,blockPos,context);
     }
+
+    @Override
+    public VoxelShape getBlockSupportShape(BlockState state, BlockGetter worldIn, BlockPos pos)
+    {
+        // Allow torches etc to be placed on the faces regardless of collision shape
+        return Shapes.block();
+    }
 }

--- a/src/main/java/com/ldtteam/structurize/blocks/schematic/BlockSubstitution.java
+++ b/src/main/java/com/ldtteam/structurize/blocks/schematic/BlockSubstitution.java
@@ -36,7 +36,8 @@ public class BlockSubstitution extends Block
             .sound(SoundType.WOOD)
             .instabreak() // must be before explosionResistance
             .explosionResistance(Blocks.OAK_PLANKS.getExplosionResistance())
-            .noOcclusion();
+            .noOcclusion()
+            .forceSolidOff();
     }
 
     @Override


### PR DESCRIPTION
Closes [discord request](https://discord.com/channels/472875599422291968/938589424441233458/1496101864100466748)

# Changes proposed in this pull request
- Allows supported blocks to be placed on tan placeholders, without changing their normal collision behaviour.
    - Might not work in all cases due to mojank though.
<img width="250" height="360" alt="image" src="https://github.com/user-attachments/assets/c9774680-316c-4954-8c77-cb31c693b898" />
- Also preserves farmland and paths underneath.
<img width="292" height="263" alt="image" src="https://github.com/user-attachments/assets/e9615ee0-50eb-4cac-be5a-74f274c19f06" />

## Testing
- [x] Yes I tested this before submitting it.
- [ ] I also did a multiplayer test.

Review please (should port)